### PR TITLE
INTERLOK-3058 metadata assertion

### DIFF
--- a/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyExists.java
+++ b/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyExists.java
@@ -27,17 +27,15 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @service-test-config assert-metadata-key-exists
  */
 @XStreamAlias("assert-metadata-key-exists")
-public class AssertMetadataKeyExists implements Assertion {
+public class AssertMetadataKeyExists extends AssertMetadataKeyImpl {
 
   private final static String TEST_ID = "assert-metadata-key-exists";
-
-  private String uniqueId;
-  private String key;
 
   public AssertMetadataKeyExists(){
   }
 
   public AssertMetadataKeyExists(String key){
+    this();
     setKey(key);
   }
 
@@ -49,29 +47,8 @@ public class AssertMetadataKeyExists implements Assertion {
 
   @Override
   public String expected() {
-    return  "Metadata contain key: [" + key + "]";
+    return "Metadata contains key: [" + getKey() + "]";
   }
 
-  @Override
-  public boolean showReturnedMessage() {
-    return true;
-  }
 
-  @Override
-  public void setUniqueId(String uniqueId) {
-    this.uniqueId = uniqueId;
-  }
-
-  @Override
-  public String getUniqueId() {
-    return uniqueId;
-  }
-
-  public void setKey(String key) {
-    this.key = key;
-  }
-
-  public String getKey() {
-    return key;
-  }
 }

--- a/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyImpl.java
+++ b/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyImpl.java
@@ -1,0 +1,49 @@
+/*
+    Copyright 2018 Adaptris Ltd.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.tester.runtime.messages.assertion;
+
+public abstract class AssertMetadataKeyImpl implements Assertion {
+
+  private String uniqueId;
+  private String key;
+
+  public AssertMetadataKeyImpl(){
+  }
+
+  @Override
+  public boolean showReturnedMessage() {
+    return true;
+  }
+
+  @Override
+  public void setUniqueId(String uniqueId) {
+    this.uniqueId = uniqueId;
+  }
+
+  @Override
+  public String getUniqueId() {
+    return uniqueId;
+  }
+
+  public void setKey(String key) {
+    this.key = key;
+  }
+
+  public String getKey() {
+    return key;
+  }
+}

--- a/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyNonExistent.java
+++ b/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyNonExistent.java
@@ -1,0 +1,52 @@
+/*
+    Copyright 2018 Adaptris Ltd.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.tester.runtime.messages.assertion;
+
+import com.adaptris.tester.runtime.ServiceTestConfig;
+import com.adaptris.tester.runtime.ServiceTestException;
+import com.adaptris.tester.runtime.messages.TestMessage;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Checks that a metadata key does not exist in {@link TestMessage#getMessageHeaders()}
+ *
+ * @service-test-config assert-metadata-key-does-not-exist
+ */
+@XStreamAlias("assert-metadata-key-does-not-exist")
+public class AssertMetadataKeyNonExistent extends AssertMetadataKeyImpl {
+
+  private final static String TEST_ID = "assert-metadata-key-does-not-exist";
+
+  public AssertMetadataKeyNonExistent(){
+  }
+
+  public AssertMetadataKeyNonExistent(String key){
+    setKey(key);
+  }
+
+  @Override
+  public AssertionResult execute(TestMessage actual, ServiceTestConfig config) throws ServiceTestException {
+    String message = String.format("Assertion Failure: [%s] metadata contains key: [%s]", TEST_ID, getKey());
+    return new AssertionResult(getUniqueId(), TEST_ID, !actual.getMessageHeaders().containsKey(getKey()), message);
+  }
+
+  @Override
+  public String expected() {
+    return "Metadata does not contain key: [" + getKey() + "]";
+  }
+
+}

--- a/src/main/java/com/adaptris/tester/runtime/services/sources/DefaultConfigSource.java
+++ b/src/main/java/com/adaptris/tester/runtime/services/sources/DefaultConfigSource.java
@@ -1,0 +1,40 @@
+/*
+    Copyright 2018 Adaptris Ltd.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.tester.runtime.services.sources;
+
+import com.adaptris.annotation.ComponentProfile;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Extension of {@link FileSource} that simply defaults to
+ * {@code file:///${service.tester.working.directory}/src/main/interlok/config/adapter.xml}.
+ * 
+ * 
+ * @service-test-config default-config-file-source
+ */
+@XStreamAlias("default-config-file-source")
+@ComponentProfile(since = "3.9.3")
+public class DefaultConfigSource extends FileSource {
+
+  private static final String DEFAULT_SRC = "file:///${service.tester.working.directory}/src/main/interlok/config/adapter.xml";
+
+  public DefaultConfigSource(){
+    super();
+    setFile(DEFAULT_SRC);
+  }
+
+}

--- a/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyExistsTest.java
+++ b/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyExistsTest.java
@@ -16,14 +16,10 @@
 
 package com.adaptris.tester.runtime.messages.assertion;
 
+import java.util.Collections;
+import org.junit.Test;
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.messages.TestMessage;
-import com.adaptris.util.KeyValuePairSet;
-import org.junit.Test;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 public class AssertMetadataKeyExistsTest extends AssertionCase{
 
@@ -48,6 +44,7 @@ public class AssertMetadataKeyExistsTest extends AssertionCase{
     assertEquals("Assertion Failure: [assert-metadata-key-exists] metadata does not contain key: [key1]", result.getMessage());
   }
 
+  @Test
   public void testShowReturnedMessage(){
     assertTrue(createAssertion().showReturnedMessage());
   }

--- a/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyExistsTest.java
+++ b/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyExistsTest.java
@@ -35,7 +35,7 @@ public class AssertMetadataKeyExistsTest extends AssertionCase{
 
   @Test
   public void testExpected(){
-    assertEquals("Metadata contain key: [key1]", createAssertion().expected());
+    assertEquals("Metadata contains key: [key1]", createAssertion().expected());
   }
 
   @Test

--- a/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyNonExistentTest.java
+++ b/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyNonExistentTest.java
@@ -1,0 +1,59 @@
+/*
+    Copyright 2018 Adaptris Ltd.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.tester.runtime.messages.assertion;
+
+import java.util.Collections;
+import org.junit.Test;
+import com.adaptris.tester.runtime.ServiceTestConfig;
+import com.adaptris.tester.runtime.messages.TestMessage;
+
+public class AssertMetadataKeyNonExistentTest extends AssertionCase{
+
+  public AssertMetadataKeyNonExistentTest(String name) {
+    super(name);
+  }
+
+  @Test
+  public void testExecute() throws Exception {
+    assertFalse(createAssertion()
+        .execute(new TestMessage(Collections.singletonMap("key1", "value1"), "payload"), new ServiceTestConfig()).isPassed());
+    assertTrue(createAssertion()
+        .execute(new TestMessage(Collections.singletonMap("key2", "value1"), "payload"), new ServiceTestConfig()).isPassed());
+  }
+
+  @Test
+  public void testExpected(){
+    assertEquals("Metadata does not contain key: [key1]", createAssertion().expected());
+  }
+
+  @Test
+  public void testGetMessage() throws Exception {
+    AssertionResult result  = createAssertion().execute(new TestMessage(), new ServiceTestConfig());
+    assertEquals("Assertion Failure: [assert-metadata-key-does-not-exist] metadata contains key: [key1]",
+        result.getMessage());
+  }
+
+  @Test
+  public void testShowReturnedMessage(){
+    assertTrue(createAssertion().showReturnedMessage());
+  }
+
+  @Override
+  protected Assertion createAssertion() {
+    return new AssertMetadataKeyNonExistent("key1");
+  }
+}

--- a/src/test/java/com/adaptris/tester/runtime/services/sources/DefaultConfigSourceTest.java
+++ b/src/test/java/com/adaptris/tester/runtime/services/sources/DefaultConfigSourceTest.java
@@ -1,0 +1,38 @@
+/*
+    Copyright 2018 Adaptris Ltd.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.tester.runtime.services.sources;
+
+import org.junit.Test;
+
+
+public class DefaultConfigSourceTest extends SourceCase{
+
+  public DefaultConfigSourceTest(String name) {
+    super(name);
+  }
+
+  @Test
+  public void testGetFile() throws Exception {
+    DefaultConfigSource src = new DefaultConfigSource();
+    assertEquals("file:///${service.tester.working.directory}/src/main/interlok/config/adapter.xml", src.getFile());
+  }
+
+  @Override
+  protected Source createSource() {
+    return new DefaultConfigSource();
+  }
+}


### PR DESCRIPTION
Added metadata-key-does-not-exist assertion
Added a default-config-source that just extends File:Source and defaults to `src/main/interlok/config/adapter.xml`
