### PR TITLE
INTERLOK 3069 + 3075 + 3131  (showing service-tester some love)

### DIFF
--- a/interlok-service-tester-gradle/build.gradle
+++ b/interlok-service-tester-gradle/build.gradle
@@ -92,7 +92,9 @@ javadoc {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
     options.linksOffline(interlokCommonJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-common-$interlokCoreVersion-javadoc.jar")
     taglets = ["com.adaptris.taglet.ConfigTaglet", "com.adaptris.taglet.LicenseTaglet", "com.adaptris.taglet.JUnitTaglet", "com.adaptris.taglet.ServiceTestTaglet"]
+    options.tags('apiNote:a:API Note:', 'implSpec:a:Implementation Requirements:','implNote:a:Implementation Note:')
     options.addStringOption "tagletpath", configurations.javadoc.asPath
+    options.tags('apiNote:a:API Note:', 'implSpec:a:Implementation Requirements:','implNote:a:Implementation Note:')
     options.group ("Service Tester - Entry Point", ["com.adaptris.tester.runners.*" , "com.adaptris.tester.runners"]).
       group ("Service Tester - Report Configuration and Creation", ["com.adaptris.tester.report.junit.*" , "com.adaptris.tester.report.junit"]).
       group ("Service Tester - Runtime Configuration and Execution", ["com.adaptris.tester.runtime.*" , "com.adaptris.tester.runtime"]).
@@ -115,6 +117,8 @@ task umlJavadoc(type: Javadoc) {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
     options.linksOffline(interlokCommonJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-common-$interlokCoreVersion-javadoc.jar")
     options.docletpath = configurations.umlDoclet.files.asType(List)
+    options.tags('apiNote:a:API Note:', 'implSpec:a:Implementation Requirements:','implNote:a:Implementation Note:')
+    options.tags('apiNote:a:API Note:', 'implSpec:a:Implementation Requirements:','implNote:a:Implementation Note:')
     options.doclet = "nl.talsmasoftware.umldoclet.UMLDoclet"
     options.group ("Service Tester - Entry Point", ["com.adaptris.tester.runners.*" , "com.adaptris.tester.runners"]).
       group ("Service Tester - Report Configuration and Creation", ["com.adaptris.tester.report.junit.*" , "com.adaptris.tester.report.junit"]).

--- a/interlok-service-tester-gradle/build.gradle
+++ b/interlok-service-tester-gradle/build.gradle
@@ -92,7 +92,6 @@ javadoc {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
     options.linksOffline(interlokCommonJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-common-$interlokCoreVersion-javadoc.jar")
     taglets = ["com.adaptris.taglet.ConfigTaglet", "com.adaptris.taglet.LicenseTaglet", "com.adaptris.taglet.JUnitTaglet", "com.adaptris.taglet.ServiceTestTaglet"]
-    options.tags('apiNote:a:API Note:', 'implSpec:a:Implementation Requirements:','implNote:a:Implementation Note:')
     options.addStringOption "tagletpath", configurations.javadoc.asPath
     options.tags('apiNote:a:API Note:', 'implSpec:a:Implementation Requirements:','implNote:a:Implementation Note:')
     options.group ("Service Tester - Entry Point", ["com.adaptris.tester.runners.*" , "com.adaptris.tester.runners"]).
@@ -117,7 +116,6 @@ task umlJavadoc(type: Javadoc) {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
     options.linksOffline(interlokCommonJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-common-$interlokCoreVersion-javadoc.jar")
     options.docletpath = configurations.umlDoclet.files.asType(List)
-    options.tags('apiNote:a:API Note:', 'implSpec:a:Implementation Requirements:','implNote:a:Implementation Note:')
     options.tags('apiNote:a:API Note:', 'implSpec:a:Implementation Requirements:','implNote:a:Implementation Note:')
     options.doclet = "nl.talsmasoftware.umldoclet.UMLDoclet"
     options.group ("Service Tester - Entry Point", ["com.adaptris.tester.runners.*" , "com.adaptris.tester.runners"]).

--- a/interlok-service-tester-json/build.gradle
+++ b/interlok-service-tester-json/build.gradle
@@ -93,6 +93,7 @@ javadoc {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
     options.linksOffline(interlokCommonJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-common-$interlokCoreVersion-javadoc.jar")
     taglets = ["com.adaptris.taglet.ConfigTaglet", "com.adaptris.taglet.LicenseTaglet", "com.adaptris.taglet.JUnitTaglet", "com.adaptris.taglet.ServiceTestTaglet"]
+    options.tags('apiNote:a:API Note:', 'implSpec:a:Implementation Requirements:','implNote:a:Implementation Note:')
     options.addStringOption "tagletpath", configurations.javadoc.asPath
     options.group ("Service Tester - Entry Point", ["com.adaptris.tester.runners.*" , "com.adaptris.tester.runners"]).
       group ("Service Tester - Report Configuration and Creation", ["com.adaptris.tester.report.junit.*" , "com.adaptris.tester.report.junit"]).
@@ -116,6 +117,7 @@ task umlJavadoc(type: Javadoc) {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
     options.linksOffline(interlokCommonJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-common-$interlokCoreVersion-javadoc.jar")
     options.docletpath = configurations.umlDoclet.files.asType(List)
+    options.tags('apiNote:a:API Note:', 'implSpec:a:Implementation Requirements:','implNote:a:Implementation Note:')
     options.doclet = "nl.talsmasoftware.umldoclet.UMLDoclet"
     options.group ("Service Tester - Entry Point", ["com.adaptris.tester.runners.*" , "com.adaptris.tester.runners"]).
       group ("Service Tester - Report Configuration and Creation", ["com.adaptris.tester.report.junit.*" , "com.adaptris.tester.report.junit"]).

--- a/interlok-service-tester-json/build.gradle
+++ b/interlok-service-tester-json/build.gradle
@@ -1,5 +1,6 @@
 ext {
   componentName='Interlok Service Tester/JSON'
+  jacksonVersion = "2.10.2"
 }
 
 dependencies {
@@ -8,6 +9,9 @@ dependencies {
     exclude group: 'com.vaadin.external.google', module: 'android-json'
   }
   compile ("org.json:json:20190722")
+  compile ("com.jayway.jsonpath:json-path:2.4.0")
+  compile ("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
+  compile ("com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")
 
   // Custom service-tester taglets
   javadoc project(":interlok-service-tester")

--- a/interlok-service-tester-json/src/main/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPathEquals.java
+++ b/interlok-service-tester-json/src/main/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPathEquals.java
@@ -48,11 +48,6 @@ public class AssertJsonPathEquals implements Assertion {
   }
 
   @Override
-  @Deprecated
-  public void setUniqueId(String uniqueId) {
-  }
-
-  @Override
   public String expected() {
     return "Value [" + getValue() + "] at JSONPath [" + getJsonPath() + "]";
   }

--- a/interlok-service-tester-json/src/main/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPathEquals.java
+++ b/interlok-service-tester-json/src/main/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPathEquals.java
@@ -1,0 +1,91 @@
+package com.adaptris.tester.runtime.messages.assertion.json;
+
+import java.util.EnumSet;
+import com.adaptris.tester.runtime.ServiceTestConfig;
+import com.adaptris.tester.runtime.ServiceTestException;
+import com.adaptris.tester.runtime.messages.TestMessage;
+import com.adaptris.tester.runtime.messages.assertion.Assertion;
+import com.adaptris.tester.runtime.messages.assertion.AssertionResult;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.ReadContext;
+import com.jayway.jsonpath.spi.json.JsonSmartJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+
+/**
+ * Assert that a JSON Path resolves to some value.
+ * 
+ * @service-test-config assert-jsonpath-equals
+ *
+ */
+@XStreamAlias("assert-jsonpath-equals")
+public class AssertJsonPathEquals implements Assertion {
+
+  private static final String ASSERT_JSONPATH_EQUALS = "assert-jsonpath-equals";
+  private String jsonPath;
+  private String value;
+
+  private transient Configuration jsonConfig = new Configuration.ConfigurationBuilder().jsonProvider(new JsonSmartJsonProvider())
+      .mappingProvider(new JacksonMappingProvider()).options(EnumSet.noneOf(Option.class)).build();
+
+
+  public AssertJsonPathEquals() {
+
+  }
+
+  @Override
+  public AssertionResult execute(TestMessage actual, ServiceTestConfig config) throws ServiceTestException {
+    try {
+      ReadContext context = JsonPath.parse(actual.getPayload(), jsonConfig);
+      String xpathResult = context.read(getJsonPath());
+      String message = String.format("Assertion Failure: [%s] Expected [%s] Returned [%s]", ASSERT_JSONPATH_EQUALS, getValue(), xpathResult);
+      return new AssertionResult(ASSERT_JSONPATH_EQUALS, getValue().equals(xpathResult), message);
+    } catch (Exception e) {
+      throw ServiceTestException.wrapException(e);
+    }
+  }
+
+  @Override
+  @Deprecated
+  public void setUniqueId(String uniqueId) {
+  }
+
+  @Override
+  public String expected() {
+    return "Value [" + getValue() + "] at JSONPath [" + getJsonPath() + "]";
+  }
+
+  @Override
+  public boolean showReturnedMessage() {
+    return true;
+  }
+
+  public String getJsonPath() {
+    return jsonPath;
+  }
+
+  public void setJsonPath(String jsonPath) {
+    this.jsonPath = jsonPath;
+  }
+
+  public AssertJsonPathEquals withJsonPath(String s) {
+    setJsonPath(s);
+    return this;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  public AssertJsonPathEquals withValue(String s) {
+    setValue(s);
+    return this;
+  }
+
+}

--- a/interlok-service-tester-json/src/main/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPayloadEquals.java
+++ b/interlok-service-tester-json/src/main/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPayloadEquals.java
@@ -47,7 +47,7 @@ public class AssertJsonPayloadEquals extends PayloadAssertion {
   public AssertionResult execute(String actual) throws ServiceTestException {
     try {
       JSONCompareResult result = JSONCompare.compareJSON(getPayload(), actual, JSONCompareMode.STRICT_ORDER);
-      return new AssertionResult(getUniqueId(), "assert-json-payload-equals", !result.failed(),
+      return new AssertionResult("assert-json-payload-equals", !result.failed(),
           "Assertion Failure: [assert-json-payload-equals]\n" + result.getMessage());
     } catch (JSONException e) {
       throw new ServiceTestException(e);

--- a/interlok-service-tester-json/src/main/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPayloadEqualsFile.java
+++ b/interlok-service-tester-json/src/main/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPayloadEqualsFile.java
@@ -48,7 +48,7 @@ public class AssertJsonPayloadEqualsFile extends AssertPayloadEqualsFile {
   public AssertionResult checkResults(String actual, String expected) throws ServiceTestException{
     try {
       JSONCompareResult result = JSONCompare.compareJSON(expected, actual, JSONCompareMode.STRICT);
-      return new AssertionResult(getUniqueId(), "assert-json-payload-equals-file", !result.failed(),
+      return new AssertionResult("assert-json-payload-equals-file", !result.failed(),
           "Assertion Failure: [assert-json-payload-equals-file]\n" + result.getMessage());
     } catch (JSONException e) {
       throw new ServiceTestException(e);

--- a/interlok-service-tester-json/src/test/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPayloadEqualsFileTest.java
+++ b/interlok-service-tester-json/src/test/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPayloadEqualsFileTest.java
@@ -27,7 +27,6 @@ import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.messages.TestMessage;
 import com.adaptris.tester.runtime.messages.assertion.Assertion;
 import com.adaptris.tester.runtime.messages.assertion.AssertionResult;
-import com.adaptris.util.GuidGenerator;
 
 public class AssertJsonPayloadEqualsFileTest extends ExampleConfigCase {
 
@@ -48,9 +47,7 @@ public class AssertJsonPayloadEqualsFileTest extends ExampleConfigCase {
 
   @Override
   protected Object retrieveObjectForSampleConfig() {
-    GuidGenerator guidGenerator = new GuidGenerator();
     Assertion assertion = createAssertion();
-    assertion.setUniqueId(guidGenerator.getUUID());
     return assertion;
   }
 

--- a/interlok-service-tester-json/src/test/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPayloadEqualsFileTest.java
+++ b/interlok-service-tester-json/src/test/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPayloadEqualsFileTest.java
@@ -28,6 +28,7 @@ import com.adaptris.tester.runtime.messages.TestMessage;
 import com.adaptris.tester.runtime.messages.assertion.Assertion;
 import com.adaptris.tester.runtime.messages.assertion.AssertionResult;
 
+@SuppressWarnings("deprecation")
 public class AssertJsonPayloadEqualsFileTest extends ExampleConfigCase {
 
   public AssertJsonPayloadEqualsFileTest() {
@@ -48,6 +49,7 @@ public class AssertJsonPayloadEqualsFileTest extends ExampleConfigCase {
   @Override
   protected Object retrieveObjectForSampleConfig() {
     Assertion assertion = createAssertion();
+    assertion.setUniqueId(null);
     return assertion;
   }
 

--- a/interlok-service-tester-json/src/test/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPayloadEqualsTest.java
+++ b/interlok-service-tester-json/src/test/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPayloadEqualsTest.java
@@ -31,6 +31,7 @@ import com.adaptris.tester.runtime.messages.assertion.PayloadAssertion;
 /**
  * @author mwarman
  */
+@SuppressWarnings("deprecation")
 public class AssertJsonPayloadEqualsTest extends ExampleConfigCase {
 
   public AssertJsonPayloadEqualsTest() {
@@ -50,6 +51,7 @@ public class AssertJsonPayloadEqualsTest extends ExampleConfigCase {
   @Override
   protected Object retrieveObjectForSampleConfig() {
     Assertion assertion = createAssertion();
+    assertion.setUniqueId(null);
     return assertion;
   }
 

--- a/interlok-service-tester-json/src/test/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPayloadEqualsTest.java
+++ b/interlok-service-tester-json/src/test/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPayloadEqualsTest.java
@@ -27,7 +27,6 @@ import com.adaptris.tester.runtime.messages.TestMessage;
 import com.adaptris.tester.runtime.messages.assertion.Assertion;
 import com.adaptris.tester.runtime.messages.assertion.AssertionResult;
 import com.adaptris.tester.runtime.messages.assertion.PayloadAssertion;
-import com.adaptris.util.GuidGenerator;
 
 /**
  * @author mwarman
@@ -50,9 +49,7 @@ public class AssertJsonPayloadEqualsTest extends ExampleConfigCase {
 
   @Override
   protected Object retrieveObjectForSampleConfig() {
-    GuidGenerator guidGenerator = new GuidGenerator();
     Assertion assertion = createAssertion();
-    assertion.setUniqueId(guidGenerator.getUUID());
     return assertion;
   }
 

--- a/interlok-service-tester-wiremock/build.gradle
+++ b/interlok-service-tester-wiremock/build.gradle
@@ -86,6 +86,7 @@ javadoc {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
     options.linksOffline(interlokCommonJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-common-$interlokCoreVersion-javadoc.jar")
     taglets = ["com.adaptris.taglet.ConfigTaglet", "com.adaptris.taglet.LicenseTaglet", "com.adaptris.taglet.JUnitTaglet", "com.adaptris.taglet.ServiceTestTaglet"]
+    options.tags('apiNote:a:API Note:', 'implSpec:a:Implementation Requirements:','implNote:a:Implementation Note:')
     options.addStringOption "tagletpath", configurations.javadoc.asPath
     options.group ("Service Tester - Entry Point", ["com.adaptris.tester.runners.*" , "com.adaptris.tester.runners"]).
       group ("Service Tester - Report Configuration and Creation", ["com.adaptris.tester.report.junit.*" , "com.adaptris.tester.report.junit"]).
@@ -109,6 +110,7 @@ task umlJavadoc(type: Javadoc) {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
     options.linksOffline(interlokCommonJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-common-$interlokCoreVersion-javadoc.jar")
     options.docletpath = configurations.umlDoclet.files.asType(List)
+    options.tags('apiNote:a:API Note:', 'implSpec:a:Implementation Requirements:','implNote:a:Implementation Note:')
     options.doclet = "nl.talsmasoftware.umldoclet.UMLDoclet"
     options.group ("Service Tester - Entry Point", ["com.adaptris.tester.runners.*" , "com.adaptris.tester.runners"]).
       group ("Service Tester - Report Configuration and Creation", ["com.adaptris.tester.report.junit.*" , "com.adaptris.tester.report.junit"]).

--- a/interlok-service-tester-xml/src/main/java/com/adaptris/tester/runtime/messages/assertion/xmlunit/AssertXmlPayloadEquals.java
+++ b/interlok-service-tester-xml/src/main/java/com/adaptris/tester/runtime/messages/assertion/xmlunit/AssertXmlPayloadEquals.java
@@ -16,16 +16,15 @@
 
 package com.adaptris.tester.runtime.messages.assertion.xmlunit;
 
+import java.io.IOException;
+import java.util.List;
+import org.custommonkey.xmlunit.DetailedDiff;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.xml.sax.SAXException;
 import com.adaptris.tester.runtime.ServiceTestException;
 import com.adaptris.tester.runtime.messages.assertion.AssertionResult;
 import com.adaptris.tester.runtime.messages.assertion.PayloadAssertion;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import org.custommonkey.xmlunit.DetailedDiff;
-import org.custommonkey.xmlunit.XMLUnit;
-import org.xml.sax.SAXException;
-
-import java.io.IOException;
-import java.util.List;
 
 /**
  * Checks if {@link com.adaptris.tester.runtime.messages.TestMessage#getPayload()} equals {@link #getPayload()}
@@ -52,7 +51,7 @@ public class AssertXmlPayloadEquals extends PayloadAssertion {
       XMLUnit.setIgnoreAttributeOrder(true);
       DetailedDiff diff = new DetailedDiff(XMLUnit.compareXML(getPayload(), actual));
       List<?> allDifferences = diff.getAllDifferences();
-      return new AssertionResult(getUniqueId(), "assert-xml-payload-equals", allDifferences.size() == 0,
+      return new AssertionResult("assert-xml-payload-equals", allDifferences.size() == 0,
           "Assertion Failure: [assert-xml-payload-equals]\n" + diff.toString());
     } catch (SAXException | IOException e) {
       throw new ServiceTestException(e);

--- a/interlok-service-tester-xml/src/main/java/com/adaptris/tester/runtime/messages/assertion/xmlunit/AssertXmlPayloadEqualsFile.java
+++ b/interlok-service-tester-xml/src/main/java/com/adaptris/tester/runtime/messages/assertion/xmlunit/AssertXmlPayloadEqualsFile.java
@@ -16,17 +16,16 @@
 
 package com.adaptris.tester.runtime.messages.assertion.xmlunit;
 
+import java.io.IOException;
+import java.util.List;
+import org.custommonkey.xmlunit.DetailedDiff;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.xml.sax.SAXException;
 import com.adaptris.tester.runtime.ServiceTestException;
 import com.adaptris.tester.runtime.messages.TestMessage;
 import com.adaptris.tester.runtime.messages.assertion.AssertPayloadEqualsFile;
 import com.adaptris.tester.runtime.messages.assertion.AssertionResult;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import org.custommonkey.xmlunit.DetailedDiff;
-import org.custommonkey.xmlunit.XMLUnit;
-import org.xml.sax.SAXException;
-
-import java.io.IOException;
-import java.util.List;
 
 /**
  * Checks if {@link TestMessage#getPayload()} equals file contents.
@@ -46,13 +45,14 @@ public class AssertXmlPayloadEqualsFile extends AssertPayloadEqualsFile {
     setFile(file);
   }
 
+  @Override
   public AssertionResult checkResults(String actual, String expected) throws ServiceTestException{
     try {
       XMLUnit.setIgnoreWhitespace(true);
       XMLUnit.setIgnoreAttributeOrder(true);
       DetailedDiff diff = new DetailedDiff(XMLUnit.compareXML(expected, actual));
       List<?> allDifferences = diff.getAllDifferences();
-      return new AssertionResult(getUniqueId(), "assert-xml-payload-equals-file", allDifferences.size() == 0,
+      return new AssertionResult("assert-xml-payload-equals-file", allDifferences.size() == 0,
           "Assertion Failure: [assert-xml-payload-equals-file]\n" + diff.toString());
     } catch (SAXException | IOException e) {
       throw new ServiceTestException(e);

--- a/interlok-service-tester-xml/src/test/java/com/adaptris/tester/runtime/messages/assertion/xmlunit/AssertXmlPayloadEqualsFileTest.java
+++ b/interlok-service-tester-xml/src/test/java/com/adaptris/tester/runtime/messages/assertion/xmlunit/AssertXmlPayloadEqualsFileTest.java
@@ -27,6 +27,7 @@ import com.adaptris.tester.runtime.messages.TestMessage;
 import com.adaptris.tester.runtime.messages.assertion.Assertion;
 import com.adaptris.tester.runtime.messages.assertion.AssertionResult;
 
+@SuppressWarnings("deprecation")
 public class AssertXmlPayloadEqualsFileTest extends ExampleConfigCase {
 
   public static final String BASE_DIR_KEY = "AssertionCase.baseDir";
@@ -48,6 +49,7 @@ public class AssertXmlPayloadEqualsFileTest extends ExampleConfigCase {
   @Override
   protected Object retrieveObjectForSampleConfig() {
     Assertion assertion = createAssertion();
+    assertion.setUniqueId(null);
     return assertion;
   }
 

--- a/interlok-service-tester-xml/src/test/java/com/adaptris/tester/runtime/messages/assertion/xmlunit/AssertXmlPayloadEqualsFileTest.java
+++ b/interlok-service-tester-xml/src/test/java/com/adaptris/tester/runtime/messages/assertion/xmlunit/AssertXmlPayloadEqualsFileTest.java
@@ -26,7 +26,6 @@ import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.messages.TestMessage;
 import com.adaptris.tester.runtime.messages.assertion.Assertion;
 import com.adaptris.tester.runtime.messages.assertion.AssertionResult;
-import com.adaptris.util.GuidGenerator;
 
 public class AssertXmlPayloadEqualsFileTest extends ExampleConfigCase {
 
@@ -48,9 +47,7 @@ public class AssertXmlPayloadEqualsFileTest extends ExampleConfigCase {
 
   @Override
   protected Object retrieveObjectForSampleConfig() {
-    GuidGenerator guidGenerator = new GuidGenerator();
     Assertion assertion = createAssertion();
-    assertion.setUniqueId(guidGenerator.getUUID());
     return assertion;
   }
 
@@ -58,7 +55,7 @@ public class AssertXmlPayloadEqualsFileTest extends ExampleConfigCase {
   public void testExecute() throws Exception {
     File file = new File(this.getClass().getClassLoader().getResource("test.xml").getFile());
     Assertion matcher = new AssertXmlPayloadEqualsFile("file:///" + file.getAbsolutePath());
-    assertTrue(matcher.execute(new TestMessage(new HashMap<String, String>(),"<xml/>"), new ServiceTestConfig()).isPassed());
+    assertTrue(matcher.execute(new TestMessage(new HashMap<String, String>(), "<xml/>"), new ServiceTestConfig()).isPassed());
     assertFalse(matcher.execute(new TestMessage(new HashMap<String, String>(),"<xml att=\"foo\" />"), new ServiceTestConfig()).isPassed());
   }
 

--- a/interlok-service-tester-xml/src/test/java/com/adaptris/tester/runtime/messages/assertion/xmlunit/AssertXmlPayloadEqualsTest.java
+++ b/interlok-service-tester-xml/src/test/java/com/adaptris/tester/runtime/messages/assertion/xmlunit/AssertXmlPayloadEqualsTest.java
@@ -27,7 +27,6 @@ import com.adaptris.tester.runtime.messages.assertion.AssertPayloadEquals;
 import com.adaptris.tester.runtime.messages.assertion.Assertion;
 import com.adaptris.tester.runtime.messages.assertion.AssertionResult;
 import com.adaptris.tester.runtime.messages.assertion.PayloadAssertion;
-import com.adaptris.util.GuidGenerator;
 
 public class AssertXmlPayloadEqualsTest extends ExampleConfigCase {
   public static final String BASE_DIR_KEY = "AssertionCase.baseDir";
@@ -48,9 +47,7 @@ public class AssertXmlPayloadEqualsTest extends ExampleConfigCase {
 
   @Override
   protected Object retrieveObjectForSampleConfig() {
-    GuidGenerator guidGenerator = new GuidGenerator();
     Assertion assertion = createAssertion();
-    assertion.setUniqueId(guidGenerator.getUUID());
     return assertion;
   }
   @Test

--- a/interlok-service-tester/build.gradle
+++ b/interlok-service-tester/build.gradle
@@ -85,6 +85,7 @@ javadoc {
     options.linksOffline(interlokCommonJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-common-$interlokCoreVersion-javadoc.jar")
     taglets = ["com.adaptris.taglet.ConfigTaglet", "com.adaptris.taglet.LicenseTaglet", "com.adaptris.taglet.JUnitTaglet", "com.adaptris.taglet.ServiceTestTaglet"]
     options.addStringOption "tagletpath", sourceSets.main.output.classesDirs.asPath + System.getProperty("path.separator") + configurations.javadoc.asPath
+    options.tags('apiNote:a:API Note:', 'implSpec:a:Implementation Requirements:','implNote:a:Implementation Note:')
     options.group ("Service Tester - Entry Point", ["com.adaptris.tester.runners.*" , "com.adaptris.tester.runners"]).
       group ("Service Tester - Report Configuration and Creation", ["com.adaptris.tester.report.junit.*" , "com.adaptris.tester.report.junit"]).
       group ("Service Tester - Runtime Configuration and Execution", ["com.adaptris.tester.runtime.*" , "com.adaptris.tester.runtime"]).
@@ -106,6 +107,7 @@ task umlJavadoc(type: Javadoc) {
   configure(options) {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
     options.linksOffline(interlokCommonJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-common-$interlokCoreVersion-javadoc.jar")
+    options.tags('apiNote:a:API Note:', 'implSpec:a:Implementation Requirements:','implNote:a:Implementation Note:')
     options.docletpath = configurations.umlDoclet.files.asType(List)
     options.doclet = "nl.talsmasoftware.umldoclet.UMLDoclet"
     options.group ("Service Tester - Entry Point", ["com.adaptris.tester.runners.*" , "com.adaptris.tester.runners"]).

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/ServiceTestException.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/ServiceTestException.java
@@ -28,11 +28,18 @@ public class ServiceTestException extends Exception {
     super(message);
   }
 
-  public ServiceTestException(String message, Exception e) {
+  public ServiceTestException(String message, Throwable e) {
     super(message, e);
   }
 
-  public ServiceTestException(Exception e) {
+  public ServiceTestException(Throwable e) {
     super(e);
+  }
+
+  public static ServiceTestException wrapException(Throwable e) {
+    if (e instanceof ServiceTestException) {
+      return (ServiceTestException) e;
+    }
+    return new ServiceTestException(e);
   }
 }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/TestComponent.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/TestComponent.java
@@ -25,5 +25,7 @@ public interface TestComponent {
    * Return the unique id.
    * @return The unique id
    */
-  String getUniqueId();
+  default String getUniqueId() {
+    return null;
+  }
 }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/TestComponent.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/TestComponent.java
@@ -25,7 +25,5 @@ public interface TestComponent {
    * Return the unique id.
    * @return The unique id
    */
-  default String getUniqueId() {
-    return null;
-  }
+  String getUniqueId();
 }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertAlwaysFail.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertAlwaysFail.java
@@ -46,12 +46,6 @@ public class AssertAlwaysFail implements Assertion {
     return "This is expected... Will always fail";
   }
 
-  @Override
-  @Deprecated
-  public void setUniqueId(String uniqueId) {
-    this.uniqueId = uniqueId;
-  }
-
   /**
    * Set value to used in {@link #showReturnedMessage()}.
    * @param showReturnedMessage value to used in {@link #showReturnedMessage()}

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertAlwaysFail.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertAlwaysFail.java
@@ -31,13 +31,14 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("assert-always-fail")
 public class AssertAlwaysFail implements Assertion {
 
+  @Deprecated
   private String uniqueId;
   private Boolean showReturnedMessage;
 
 
   @Override
   public AssertionResult execute(TestMessage actual, ServiceTestConfig config) throws ServiceTestException {
-    return new AssertionResult(getUniqueId(), "assert-always-fail", false);
+    return new AssertionResult("assert-always-fail", false);
   }
 
   @Override
@@ -46,13 +47,9 @@ public class AssertAlwaysFail implements Assertion {
   }
 
   @Override
+  @Deprecated
   public void setUniqueId(String uniqueId) {
     this.uniqueId = uniqueId;
-  }
-
-  @Override
-  public String getUniqueId() {
-    return this.uniqueId;
   }
 
   /**

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertLinePayloadEquals.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertLinePayloadEquals.java
@@ -45,13 +45,6 @@ public class AssertLinePayloadEquals implements Assertion {
     }
   }
 
-  @Override
-  @Deprecated
-  public void setUniqueId(String uniqueId) {
-    this.uniqueId = uniqueId;
-  }
-
-
   public void setExpectedLines(List<String> expectedLines) {
     this.expectedLines = expectedLines;
   }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertLinePayloadEquals.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertLinePayloadEquals.java
@@ -1,16 +1,15 @@
 package com.adaptris.tester.runtime.messages.assertion;
 
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.io.IOUtils;
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.ServiceTestException;
 import com.adaptris.tester.runtime.messages.TestMessage;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
-import org.apache.commons.io.IOUtils;
-
-import java.io.IOException;
-import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Checks if {@link com.adaptris.tester.runtime.messages.TestMessage#getPayload()} equals {@link #getExpectedLines()}
@@ -22,6 +21,7 @@ import java.util.List;
 @XStreamAlias("assert-line-payload-equals")
 public class AssertLinePayloadEquals implements Assertion {
 
+  @Deprecated
   private String uniqueId;
 
   @XStreamImplicit(itemFieldName = "line")
@@ -39,21 +39,18 @@ public class AssertLinePayloadEquals implements Assertion {
   public AssertionResult execute(TestMessage actual, ServiceTestConfig config) throws ServiceTestException {
     try {
       List<String> actualLines = IOUtils.readLines(new StringReader(actual.getPayload()));
-      return new AssertionResult(getUniqueId(), "assert-lines-payload-equals", expectedLines.equals(actualLines));
+      return new AssertionResult("assert-lines-payload-equals", expectedLines.equals(actualLines));
     } catch (IOException e) {
       throw new ServiceTestException(e);
     }
   }
 
   @Override
+  @Deprecated
   public void setUniqueId(String uniqueId) {
     this.uniqueId = uniqueId;
   }
 
-  @Override
-  public String getUniqueId() {
-    return uniqueId;
-  }
 
   public void setExpectedLines(List<String> expectedLines) {
     this.expectedLines = expectedLines;

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertLinePayloadEqualsFile.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertLinePayloadEqualsFile.java
@@ -1,12 +1,11 @@
 package com.adaptris.tester.runtime.messages.assertion;
 
-import com.adaptris.tester.runtime.ServiceTestException;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import org.apache.commons.io.IOUtils;
-
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.List;
+import org.apache.commons.io.IOUtils;
+import com.adaptris.tester.runtime.ServiceTestException;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Checks if {@link com.adaptris.tester.runtime.messages.TestMessage#getPayload()} equals lines of {@link #getFile()}
@@ -26,11 +25,12 @@ public class AssertLinePayloadEqualsFile extends AssertPayloadEqualsFile {
     super(file);
   }
 
+  @Override
   public AssertionResult checkResults(String actual, String expected) throws ServiceTestException{
     try {
       List<String> expectedLines = IOUtils.readLines(new StringReader(expected));
       List<String> actualLines = IOUtils.readLines(new StringReader(actual));
-      return new AssertionResult(getUniqueId(), "assert-lines-payload-equals", expectedLines.equals(actualLines));
+      return new AssertionResult("assert-lines-payload-equals", expectedLines.equals(actualLines));
     } catch (IOException e) {
       throw new ServiceTestException(e);
     }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataContains.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataContains.java
@@ -16,10 +16,9 @@
 
 package com.adaptris.tester.runtime.messages.assertion;
 
+import java.util.Map;
 import com.adaptris.util.KeyValuePairSet;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-
-import java.util.Map;
 
 /**
  * Checks if all keys and corresponding values set in {@link #getMessageHeaders()} are present in
@@ -44,9 +43,9 @@ public class AssertMetadataContains extends MetadataAssertion {
     for(Map.Entry<String, String> entry :  getMessageHeaders().entrySet()){
       if(!(actual.containsKey(entry.getKey()) && actual.get(entry.getKey()).equals(entry.getValue()))){
         String message = String.format("Assertion Failure: [%s] metadata does not contain kvp: {%s=%s}", testType, entry.getKey(), entry.getValue());
-        return new AssertionResult(getUniqueId(), testType, false, message);
+        return new AssertionResult(testType, false, message);
       }
     }
-    return new AssertionResult(getUniqueId(), testType, true);
+    return new AssertionResult(testType, true);
   }
 }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataEquals.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataEquals.java
@@ -16,10 +16,9 @@
 
 package com.adaptris.tester.runtime.messages.assertion;
 
+import java.util.Map;
 import com.adaptris.util.KeyValuePairSet;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-
-import java.util.Map;
 
 /**
  * Checks if {@link #getMessageHeaders()} equals {@link com.adaptris.tester.runtime.messages.TestMessage#getMessageHeaders()}
@@ -40,6 +39,6 @@ public class AssertMetadataEquals extends MetadataAssertion {
 
   @Override
   public AssertionResult execute(Map<String, String> actual) {
-    return new AssertionResult(getUniqueId(), "assert-metadata-equals", getMessageHeaders().equals(actual));
+    return new AssertionResult("assert-metadata-equals", getMessageHeaders().equals(actual));
   }
 }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyExists.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyExists.java
@@ -42,7 +42,7 @@ public class AssertMetadataKeyExists extends AssertMetadataKeyImpl {
   @Override
   public AssertionResult execute(TestMessage actual, ServiceTestConfig config) throws ServiceTestException {
     String message = String.format("Assertion Failure: [%s] metadata does not contain key: [%s]", TEST_ID, getKey());
-    return new AssertionResult(getUniqueId(), TEST_ID, actual.getMessageHeaders().containsKey(getKey()), message);
+    return new AssertionResult(TEST_ID, actual.getMessageHeaders().containsKey(getKey()), message);
   }
 
   @Override

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyImpl.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyImpl.java
@@ -18,6 +18,7 @@ package com.adaptris.tester.runtime.messages.assertion;
 
 public abstract class AssertMetadataKeyImpl implements Assertion {
 
+  @Deprecated
   private String uniqueId;
   private String key;
 
@@ -30,13 +31,9 @@ public abstract class AssertMetadataKeyImpl implements Assertion {
   }
 
   @Override
+  @Deprecated
   public void setUniqueId(String uniqueId) {
     this.uniqueId = uniqueId;
-  }
-
-  @Override
-  public String getUniqueId() {
-    return uniqueId;
   }
 
   public void setKey(String key) {

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyImpl.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyImpl.java
@@ -30,12 +30,6 @@ public abstract class AssertMetadataKeyImpl implements Assertion {
     return true;
   }
 
-  @Override
-  @Deprecated
-  public void setUniqueId(String uniqueId) {
-    this.uniqueId = uniqueId;
-  }
-
   public void setKey(String key) {
     this.key = key;
   }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyNonExistent.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyNonExistent.java
@@ -41,7 +41,7 @@ public class AssertMetadataKeyNonExistent extends AssertMetadataKeyImpl {
   @Override
   public AssertionResult execute(TestMessage actual, ServiceTestConfig config) throws ServiceTestException {
     String message = String.format("Assertion Failure: [%s] metadata contains key: [%s]", TEST_ID, getKey());
-    return new AssertionResult(getUniqueId(), TEST_ID, !actual.getMessageHeaders().containsKey(getKey()), message);
+    return new AssertionResult(TEST_ID, !actual.getMessageHeaders().containsKey(getKey()), message);
   }
 
   @Override

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataMatchesRegex.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataMatchesRegex.java
@@ -16,12 +16,11 @@
 
 package com.adaptris.tester.runtime.messages.assertion;
 
-import com.adaptris.util.KeyValuePairSet;
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import com.adaptris.util.KeyValuePairSet;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
  * Checks if all keys and corresponding regular expression in values set in {@link #getMessageHeaders()} match
@@ -51,13 +50,13 @@ public class AssertMetadataMatchesRegex extends MetadataAssertion {
         Matcher m = pattern.matcher(actualValue);
         if (!m.find()) {
           String message = String.format("Assertion Failure: [%s] metadata contains [%s] but does not match [%s]", testType, entry.getKey(), entry.getValue());
-          return new AssertionResult(getUniqueId(), testType, false, message);
+          return new AssertionResult(testType, false, message);
         }
       } else {
         String message = String.format("Assertion Failure: [%s] message doesn't contain: [%s]", testType, entry.getKey());
-        return new AssertionResult(getUniqueId(), testType, false, message);
+        return new AssertionResult(testType, false, message);
       }
     }
-    return new AssertionResult(getUniqueId(), testType, true);
+    return new AssertionResult(testType, true);
   }
 }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataNotEquals.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataNotEquals.java
@@ -16,10 +16,9 @@
 
 package com.adaptris.tester.runtime.messages.assertion;
 
+import java.util.Map;
 import com.adaptris.util.KeyValuePairSet;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-
-import java.util.Map;
 
 /**
  * Checks if all keys and corresponding values set in {@link #getMessageHeaders()} are not present in
@@ -42,10 +41,10 @@ public class AssertMetadataNotEquals extends MetadataAssertion {
   public AssertionResult execute(Map<String, String> actual) {
     String testType = "assert-metadata-not-equals";
     for(Map.Entry<String, String> entry :  actual.entrySet()){
-      if((getMessageHeaders().containsKey(entry.getKey()) && getMessageHeaders().get(entry.getKey()).equals(entry.getValue()))){
-        return new AssertionResult(getUniqueId(), testType, false);
+      if(getMessageHeaders().containsKey(entry.getKey()) && getMessageHeaders().get(entry.getKey()).equals(entry.getValue())){
+        return new AssertionResult(testType, false);
       }
     }
-    return new AssertionResult(getUniqueId(), "assert-metadata-not-equals", true);
+    return new AssertionResult("assert-metadata-not-equals", true);
   }
 }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertNextServiceId.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertNextServiceId.java
@@ -29,12 +29,13 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("assert-next-service-id")
 public class AssertNextServiceId implements Assertion {
 
+  @Deprecated
   private String uniqueId;
   private String value;
 
   @Override
   public AssertionResult execute(TestMessage actual, ServiceTestConfig config) throws ServiceTestException {
-    return new AssertionResult(getUniqueId(), "assert-next-service-id", actual.getNextServiceId().equals(getValue()));
+    return new AssertionResult("assert-next-service-id", actual.getNextServiceId().equals(getValue()));
   }
 
   @Override
@@ -64,12 +65,8 @@ public class AssertNextServiceId implements Assertion {
   }
 
   @Override
+  @Deprecated
   public void setUniqueId(String uniqueId) {
     this.uniqueId = uniqueId;
-  }
-
-  @Override
-  public String getUniqueId() {
-    return this.uniqueId;
   }
 }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertNextServiceId.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertNextServiceId.java
@@ -64,9 +64,4 @@ public class AssertNextServiceId implements Assertion {
     return value;
   }
 
-  @Override
-  @Deprecated
-  public void setUniqueId(String uniqueId) {
-    this.uniqueId = uniqueId;
-  }
 }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertPayloadContains.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertPayloadContains.java
@@ -36,6 +36,6 @@ public class AssertPayloadContains extends PayloadAssertion {
 
   @Override
   public AssertionResult execute(String actual) {
-    return new AssertionResult(getUniqueId(), "assert-payload-contains", actual.contains(getPayload()));
+    return new AssertionResult("assert-payload-contains", actual.contains(getPayload()));
   }
 }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertPayloadEquals.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertPayloadEquals.java
@@ -36,6 +36,6 @@ public class AssertPayloadEquals extends PayloadAssertion {
 
   @Override
   public AssertionResult execute(String actual) {
-    return new AssertionResult(getUniqueId(), "assert-payload-equals", getPayload().equals(actual));
+    return new AssertionResult("assert-payload-equals", getPayload().equals(actual));
   }
 }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertPayloadEqualsFile.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertPayloadEqualsFile.java
@@ -47,12 +47,6 @@ public class AssertPayloadEqualsFile implements Assertion {
     setFile(file);
   }
 
-  @Deprecated
-  @Override
-  public void setUniqueId(String uniqueId) {
-    this.uniqueId = uniqueId;
-  }
-
   public String getFile() {
     return file;
   }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertPayloadEqualsFile.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertPayloadEqualsFile.java
@@ -16,18 +16,15 @@
 
 package com.adaptris.tester.runtime.messages.assertion;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
 import com.adaptris.core.CoreException;
 import com.adaptris.fs.FsException;
-import com.adaptris.fs.FsWorker;
-import com.adaptris.fs.NioWorker;
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.ServiceTestException;
 import com.adaptris.tester.runtime.messages.TestMessage;
 import com.adaptris.tester.utils.FsHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-
-import java.io.IOException;
-import java.net.URISyntaxException;
 
 /**
  * Checks if {@link com.adaptris.tester.runtime.messages.TestMessage#getPayload()} equals file contents.
@@ -39,6 +36,7 @@ import java.net.URISyntaxException;
 @XStreamAlias("assert-payload-equals-file")
 public class AssertPayloadEqualsFile implements Assertion {
 
+  @Deprecated
   private String uniqueId;
   private String file;
 
@@ -49,14 +47,10 @@ public class AssertPayloadEqualsFile implements Assertion {
     setFile(file);
   }
 
+  @Deprecated
   @Override
   public void setUniqueId(String uniqueId) {
     this.uniqueId = uniqueId;
-  }
-
-  @Override
-  public String getUniqueId() {
-    return uniqueId;
   }
 
   public String getFile() {
@@ -83,7 +77,7 @@ public class AssertPayloadEqualsFile implements Assertion {
   }
 
   public AssertionResult checkResults(String actual, String expected) throws ServiceTestException {
-    return new AssertionResult(getUniqueId(), "assert-payload-equals-file", expected.equals(actual));
+    return new AssertionResult("assert-payload-equals-file", expected.equals(actual));
   }
 
   @Override

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathBoolean.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathBoolean.java
@@ -39,16 +39,13 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("assert-xpath-boolean")
 public class AssertXpathBoolean extends XpathCommon implements Assertion {
 
+  @Deprecated
   private String uniqueId;
 
   @Override
+  @Deprecated
   public void setUniqueId(String uniqueId) {
     this.uniqueId = uniqueId;
-  }
-
-  @Override
-  public String getUniqueId() {
-    return uniqueId;
   }
 
   @Override
@@ -57,7 +54,7 @@ public class AssertXpathBoolean extends XpathCommon implements Assertion {
       final String type = "assert-xpath-boolean";
       final boolean xpathResult = selectSingleBoolean(actual.getPayload());
       String message = String.format("Assertion Failure: [%s] Expected [%s] Returned [%s]", type, "true", xpathResult);
-      return new AssertionResult(getUniqueId(), type, xpathResult, message);
+      return new AssertionResult(type, xpathResult, message);
     } catch (XpathCommonException e) {
       throw new ServiceTestException(e);
     }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathBoolean.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathBoolean.java
@@ -43,12 +43,6 @@ public class AssertXpathBoolean extends XpathCommon implements Assertion {
   private String uniqueId;
 
   @Override
-  @Deprecated
-  public void setUniqueId(String uniqueId) {
-    this.uniqueId = uniqueId;
-  }
-
-  @Override
   public AssertionResult execute(TestMessage actual, ServiceTestConfig config) throws ServiceTestException {
     try {
       final String type = "assert-xpath-boolean";

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathEquals.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathEquals.java
@@ -42,17 +42,14 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("assert-xpath-equals")
 public class AssertXpathEquals extends XpathCommon implements Assertion {
 
+  @Deprecated
   private String uniqueId;
   private String value;
 
   @Override
+  @Deprecated
   public void setUniqueId(String uniqueId) {
     this.uniqueId = uniqueId;
-  }
-
-  @Override
-  public String getUniqueId() {
-    return uniqueId;
   }
 
   /**
@@ -77,7 +74,7 @@ public class AssertXpathEquals extends XpathCommon implements Assertion {
       final String type = "assert-xpath-equals";
       final String xpathResult = nodeToString(selectSingleNode(actual.getPayload()));
       String message = String.format("Assertion Failure: [%s] Expected [%s] Returned [%s]", type, getValue(), xpathResult);
-      return new AssertionResult(getUniqueId(), type, getValue().equals(xpathResult), message);
+      return new AssertionResult(type, getValue().equals(xpathResult), message);
     } catch (XpathCommonException e) {
       throw new ServiceTestException(e);
     }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathEquals.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathEquals.java
@@ -46,12 +46,6 @@ public class AssertXpathEquals extends XpathCommon implements Assertion {
   private String uniqueId;
   private String value;
 
-  @Override
-  @Deprecated
-  public void setUniqueId(String uniqueId) {
-    this.uniqueId = uniqueId;
-  }
-
   /**
    * Set value to check against xpath result.
    * @param value Value to check against xpath result

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/Assertion.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/Assertion.java
@@ -32,10 +32,23 @@ public interface Assertion extends TestComponent {
    * Sets the unique id
    * 
    * @param uniqueId The unique id
+   * @implNote The default implementation is no-op
    * @deprecated since 3.10 with no replacement since it adds no value.
    */
   @Deprecated
-  void setUniqueId(String uniqueId);
+  default void setUniqueId(String uniqueId) {
+    
+  }
+
+  /**
+   * Default method since setUniqueID is deprecated
+   * 
+   * @implNote The default implementation just returns null
+   */
+  @Override
+  default String getUniqueId() {
+    return null;
+  }
 
   /**
    * Execute assertion against test message.

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/Assertion.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/Assertion.java
@@ -30,8 +30,11 @@ public interface Assertion extends TestComponent {
 
   /**
    * Sets the unique id
+   * 
    * @param uniqueId The unique id
+   * @deprecated since 3.10 with no replacement since it adds no value.
    */
+  @Deprecated
   void setUniqueId(String uniqueId);
 
   /**

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertionResult.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertionResult.java
@@ -21,19 +21,17 @@ package com.adaptris.tester.runtime.messages.assertion;
  */
 public class AssertionResult {
 
-  private final String uniqueId;
   private final String type;
   private final boolean passed;
   private String message;
 
-  public AssertionResult(String uniqueId, String type, boolean passed){
-    this.uniqueId = uniqueId;
+  public AssertionResult(String type, boolean passed) {
     this.type = type;
     this.passed = passed;
   }
 
-  public AssertionResult(String uniqueId, String type, boolean passed, String message){
-    this(uniqueId, type, passed);
+  public AssertionResult(String type, boolean passed, String message) {
+    this(type, passed);
     this.message = message;
   }
 

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/MetadataAssertion.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/MetadataAssertion.java
@@ -19,7 +19,6 @@ package com.adaptris.tester.runtime.messages.assertion;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
 import com.adaptris.annotation.AutoPopulated;
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.messages.TestMessage;
@@ -34,6 +33,7 @@ import com.adaptris.util.KeyValuePairSet;
  */
 public abstract class MetadataAssertion implements Assertion {
 
+  @Deprecated
   private String uniqueId;
   @AutoPopulated
   private KeyValuePairSet metadata;
@@ -47,13 +47,9 @@ public abstract class MetadataAssertion implements Assertion {
   }
 
   @Override
+  @Deprecated
   public void setUniqueId(String uniqueId) {
     this.uniqueId = uniqueId;
-  }
-
-  @Override
-  public String getUniqueId() {
-    return uniqueId;
   }
 
   /**

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/MetadataAssertion.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/MetadataAssertion.java
@@ -46,12 +46,6 @@ public abstract class MetadataAssertion implements Assertion {
     setMetadata(metadata);
   }
 
-  @Override
-  @Deprecated
-  public void setUniqueId(String uniqueId) {
-    this.uniqueId = uniqueId;
-  }
-
   /**
    * Set the expected metadata kvps to be used during assertions.
    * @param metadata the expected metadata kvps

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/PayloadAssertion.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/PayloadAssertion.java
@@ -41,12 +41,6 @@ public abstract class PayloadAssertion implements Assertion {
     setPayload(payload);
   }
 
-  @Override
-  @Deprecated
-  public void setUniqueId(String uniqueId) {
-    this.uniqueId = uniqueId;
-  }
-
   /**
    * Set the expected payload to be used during assertions.
    * @param payload the expected payload

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/PayloadAssertion.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/PayloadAssertion.java
@@ -28,6 +28,7 @@ import com.adaptris.tester.runtime.messages.TestMessage;
  */
 public abstract class PayloadAssertion implements Assertion {
 
+  @Deprecated
   private String uniqueId;
   @MarshallingCDATA
   private String payload;
@@ -41,13 +42,9 @@ public abstract class PayloadAssertion implements Assertion {
   }
 
   @Override
+  @Deprecated
   public void setUniqueId(String uniqueId) {
     this.uniqueId = uniqueId;
-  }
-
-  @Override
-  public String getUniqueId() {
-    return uniqueId;
   }
 
   /**

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/AssertionsTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/AssertionsTest.java
@@ -30,14 +30,13 @@ import com.adaptris.tester.runtime.messages.assertion.AssertMetadataContains;
 import com.adaptris.tester.runtime.messages.assertion.AssertPayloadContains;
 import com.adaptris.tester.runtime.messages.assertion.Assertion;
 import com.adaptris.tester.runtime.messages.assertion.AssertionResult;
-import com.adaptris.util.GuidGenerator;
 
 public class AssertionsTest extends TCCase {
 
   @org.junit.Test
   public void testGetAssertions() throws Exception {
     Assertions a = new Assertions();
-    a.addAssertion(new StubAssertion("id", new AssertionResult("id", "type", true), "message"));
+    a.addAssertion(new StubAssertion("id", new AssertionResult("type", true), "message"));
     assertEquals(1, a.size());
     assertEquals("id", a.getAssertions().get(0).getUniqueId());
   }
@@ -45,7 +44,7 @@ public class AssertionsTest extends TCCase {
   @org.junit.Test
   public void testExecutePassed() throws Exception {
     Assertions a = new Assertions();
-    a.addAssertion(new StubAssertion("id", new AssertionResult("id", "type", true), "message"));
+    a.addAssertion(new StubAssertion("id", new AssertionResult("type", true), "message"));
     JUnitReportTestIssue issue = a.execute(new TestMessage(), new ServiceTestConfig());
     assertNull(issue);
     assertEquals("id", a.getAssertions().get(0).getUniqueId());
@@ -54,7 +53,7 @@ public class AssertionsTest extends TCCase {
   @org.junit.Test
   public void testExecuteFailed() throws Exception {
     Assertions a = new Assertions();
-    a.addAssertion(new StubAssertion("id", new AssertionResult("id", "type", false), "message-1234"));
+    a.addAssertion(new StubAssertion("id", new AssertionResult("type", false), "message-1234"));
     JUnitReportTestIssue issue = a.execute(new TestMessage(), new ServiceTestConfig());
     assertNotNull(issue);
     assertTrue(issue instanceof JUnitReportFailure);
@@ -68,8 +67,8 @@ public class AssertionsTest extends TCCase {
     Assertions a = new Assertions();
     a.setAssertions(Arrays.asList(
         new Assertion[] {
-          new StubAssertion("id", new AssertionResult("id", "type", true), "message"),
-          new StubAssertion("id", new AssertionResult("id", "type", false), "message-1234")
+            new StubAssertion("id", new AssertionResult("type", true), "message"),
+            new StubAssertion("id", new AssertionResult("type", false), "message-1234")
         })
     );
     assertEquals(2, a.size());
@@ -90,13 +89,10 @@ public class AssertionsTest extends TCCase {
   @Override
   protected Object retrieveObjectForSampleConfig() {
     Assertions a = new Assertions();
-    GuidGenerator guidGenerator = new GuidGenerator();
     Map<String, String> expected = new HashMap<>();
     expected.put("key1", "val1");
     Assertion a1 = new AssertMetadataContains(expected);
-    a1.setUniqueId(guidGenerator.getUUID());
     Assertion a2 = new AssertPayloadContains("hello");
-    a2.setUniqueId(guidGenerator.getUUID());
     a.addAssertion(a1);
     a.addAssertion(a2);
     TestCase tc = createBaseTestCase();

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/ServiceTestExceptionTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/ServiceTestExceptionTest.java
@@ -1,0 +1,32 @@
+package com.adaptris.tester.runtime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import org.junit.Test;
+
+public class ServiceTestExceptionTest {
+
+  @Test
+  public void testConstructors() {
+    ServiceTestException e = new ServiceTestException();
+    assertNull(e.getMessage());
+    e = new ServiceTestException("fail");
+    assertEquals("fail", e.getMessage());
+    Exception nested = new Exception();
+    e = new ServiceTestException(nested);
+    assertSame(nested, e.getCause());
+    e = new ServiceTestException("fail", nested);
+    assertSame(nested, e.getCause());
+    assertEquals("fail", e.getMessage());
+  }
+
+  @Test
+  public void testWrapException() {
+    ServiceTestException e = new ServiceTestException();
+    assertSame(e, ServiceTestException.wrapException(e));
+    assertNotEquals(e, ServiceTestException.wrapException(new Exception()));
+  }
+
+}

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertAlwaysFailTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertAlwaysFailTest.java
@@ -18,11 +18,13 @@ package com.adaptris.tester.runtime.messages.assertion;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.messages.TestMessage;
 
+@SuppressWarnings("deprecation")
 public class AssertAlwaysFailTest extends AssertionCase {
 
   @Test
@@ -41,7 +43,7 @@ public class AssertAlwaysFailTest extends AssertionCase {
   @Test
   public void testGetUniqueId() throws Exception {
     Assertion a = createAssertion();
-    assertEquals("id", a.getUniqueId());
+    assertNull(a.getUniqueId());
   }
 
   @Test

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertNextServiceIdTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertNextServiceIdTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.messages.TestMessage;
 
+@SuppressWarnings("deprecation")
 public class AssertNextServiceIdTest extends AssertionCase {
 
   @Test
@@ -39,12 +40,6 @@ public class AssertNextServiceIdTest extends AssertionCase {
   public void testExpected() throws Exception {
     Assertion a = createAssertion();
     assertEquals("Next service id: next-service", a.expected());
-  }
-
-  @Test
-  public void testGetUniqueId() throws Exception {
-    Assertion a = createAssertion();
-    assertEquals("id", a.getUniqueId());
   }
 
   @Test

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathBooleanTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathBooleanTest.java
@@ -25,15 +25,11 @@ import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.messages.TestMessage;
 import com.adaptris.util.KeyValuePairSet;
 
+@SuppressWarnings("deprecation")
 public class AssertXpathBooleanTest extends AssertionCase {
 
   private final static String PAYLOAD = "<root><key>value</key></root>";
 
-  @Test
-  public void testGetUniqueId() throws Exception {
-    AssertXpathBoolean a = createAssertion();
-    assertEquals("id", a.getUniqueId());
-  }
 
   @Test
   public void testExecute() throws Exception {

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathEqualsTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathEqualsTest.java
@@ -25,15 +25,10 @@ import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.messages.TestMessage;
 import com.adaptris.util.KeyValuePairSet;
 
+@SuppressWarnings("deprecation")
 public class AssertXpathEqualsTest extends AssertionCase {
 
   private final static String PAYLOAD = "<root><key>value</key></root>";
-
-  @Test
-  public void testGetUniqueId() throws Exception {
-    AssertXpathEquals a = createAssertion();
-    assertEquals("id", a.getUniqueId());
-  }
 
   @Test
   public void testGetValue() throws Exception {

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertionCase.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertionCase.java
@@ -17,8 +17,8 @@
 package com.adaptris.tester.runtime.messages.assertion;
 
 import com.adaptris.tester.STExampleConfigCase;
-import com.adaptris.util.GuidGenerator;
 
+@SuppressWarnings("deprecation")
 public abstract class AssertionCase extends STExampleConfigCase {
 
   public static final String BASE_DIR_KEY = "AssertionCase.baseDir";
@@ -31,9 +31,8 @@ public abstract class AssertionCase extends STExampleConfigCase {
 
   @Override
   protected Object retrieveObjectForSampleConfig() {
-    GuidGenerator guidGenerator = new GuidGenerator();
     Assertion assertion = createAssertion();
-    assertion.setUniqueId(guidGenerator.getUUID());
+    assertion.setUniqueId(null);
     return assertion;
   }
 


### PR DESCRIPTION
Because I was in it to add a JsonPath assertion; I ended up doing a couple of related tickets.

## INTERLOK-3069
- Add default methods to Assertion for get/set UniqueID with implNote documentation
- Deprecate Assertion#setUniqueId, and remove getUniqueId from all concrete sub-classes (so it uses the default impl).
- AssertionCase sets unique-id to null during example generation (for coverage...)
- Shouldn't break configuration since "uniqueId" will still be available to XStream for marshalling purposes; but because getUniqueId() returns null for all assertions...
- Modify build.gradles to include options.tags

## INTERLOK-3131 
- Remove UniqueID from AssertionResult

## INTERLOK-3075 
- Add a JsonPath assertion; 
- Add a helper to ServiceTestException
