### PR TITLE
INTERLOK-3144 Encode the service-tester working dir

### DIFF
--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/ServiceTestConfig.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/ServiceTestConfig.java
@@ -1,6 +1,9 @@
 package com.adaptris.tester.runtime;
 
 import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -27,10 +30,15 @@ public class ServiceTestConfig {
     return this;
   }
 
-  public ServiceTestConfig withWorkingDirectory(File workingDirectory){
-    if (workingDirectory != null) {
-      this.workingDirectory = workingDirectory;
-      this.workingDirectoryProperties.put(SERVICE_TESTER_WORKING_DIRECTORY, workingDirectory.getAbsolutePath());
+  public ServiceTestConfig withWorkingDirectory(File workingDirectory) {
+    try {
+      if (workingDirectory != null) {
+        this.workingDirectory = workingDirectory;
+        this.workingDirectoryProperties.put(SERVICE_TESTER_WORKING_DIRECTORY,
+            URLEncoder.encode(workingDirectory.getAbsolutePath(), StandardCharsets.UTF_8.name()));
+      }
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException(e);
     }
     return this;
   }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/utils/FsHelper.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/utils/FsHelper.java
@@ -1,5 +1,11 @@
 package com.adaptris.tester.utils;
 
+import static com.adaptris.core.varsub.Constants.DEFAULT_VARIABLE_POSTFIX;
+import static com.adaptris.core.varsub.Constants.DEFAULT_VARIABLE_PREFIX;
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.varsub.SimpleStringSubstitution;
 import com.adaptris.fs.FsException;
@@ -7,22 +13,11 @@ import com.adaptris.fs.FsWorker;
 import com.adaptris.fs.NioWorker;
 import com.adaptris.tester.runtime.ServiceTestConfig;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
-
-import static com.adaptris.core.varsub.Constants.DEFAULT_VARIABLE_POSTFIX;
-import static com.adaptris.core.varsub.Constants.DEFAULT_VARIABLE_PREFIX;
-
 /**
  * @author mwarman
  */
-public class FsHelper {
+public abstract class FsHelper {
 
-  private FsHelper(){
-
-  }
 
   public static File createFile(String path, ServiceTestConfig config) throws IOException, URISyntaxException, CoreException {
     path = new SimpleStringSubstitution().doSubstitution(path, config.workingDirectoryProperties, DEFAULT_VARIABLE_PREFIX, DEFAULT_VARIABLE_POSTFIX);

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/utils/FsHelperTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/utils/FsHelperTest.java
@@ -1,0 +1,43 @@
+package com.adaptris.tester.utils;
+
+import static org.junit.Assert.assertEquals;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
+import com.adaptris.core.util.XmlHelper;
+import com.adaptris.tester.runtime.ServiceTestConfig;
+
+public class FsHelperTest extends FsHelper {
+
+  @Test
+  public void testCreateFile_URL() throws Exception {
+    final String testFile = "service.xml";
+    File parentDir = new File(this.getClass().getClassLoader().getResource(testFile).getFile()).getParentFile();
+    ServiceTestConfig config = new ServiceTestConfig().withWorkingDirectory(parentDir);
+    File f = createFile("file:///${service.tester.working.directory}/" + testFile, config);
+    assertEquals(new File(parentDir, testFile), f);
+  }
+
+  @Test
+  public void testCreateFile_URLWithSpaces() throws Exception {
+    String testFile = "service.xml";
+    File parentDir = new File("/home/path/with some/spaces");
+    ServiceTestConfig config = new ServiceTestConfig().withWorkingDirectory(parentDir);
+    File f = createFile("file:///${service.tester.working.directory}/" + testFile, config);
+    assertEquals(new File(parentDir, testFile).getAbsoluteFile(), f);
+  }
+
+  @Test
+  public void testReadFile() throws Exception {
+    final String testFile = "service.xml";
+    File parentDir = new File(this.getClass().getClassLoader().getResource(testFile).getFile()).getParentFile();
+    ServiceTestConfig config = new ServiceTestConfig().withWorkingDirectory(parentDir);
+    byte[] bytes = getFileBytes("file:///${service.tester.working.directory}/" + testFile, config);
+    try (ByteArrayInputStream in = new ByteArrayInputStream(bytes)) {
+     Document document = XmlHelper.createDocument(in, DocumentBuilderFactoryBuilder.newRestrictedInstance()); 
+     assertEquals("service-collection", document.getDocumentElement().getNodeName());
+    }
+  }
+}


### PR DESCRIPTION
- Add tests for FsHelper
- Make sure the we encode the working directory with URLEncoder so that when we "file:///"+ it , it works.

There are knock-on effects based on a directory having spaces.

