### PR TITLE
Bug/interlok 2646 assert xpath equals does not support attributes

### DIFF
--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/XpathCommon.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/XpathCommon.java
@@ -12,7 +12,7 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime;
 
@@ -113,7 +113,12 @@ public class XpathCommon {
     try {
       Transformer t = TransformerFactory.newInstance().newTransformer();
       t.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
-      t.transform(new DOMSource(node), new StreamResult(sw));
+      DOMSource source = new DOMSource(node);
+      if (source.getNode().getNodeType() != Node.ATTRIBUTE_NODE) {
+        t.transform(source, new StreamResult(sw));
+      } else {
+        sw.write(source.getNode().toString());
+      }
     } catch (TransformerException e) {
       throw new XpathCommonException("Failed to convert node to string", e);
     }

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathEqualsTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathEqualsTest.java
@@ -28,7 +28,7 @@ import com.adaptris.util.KeyValuePairSet;
 @SuppressWarnings("deprecation")
 public class AssertXpathEqualsTest extends AssertionCase {
 
-  private final static String PAYLOAD = "<root><key>value</key></root>";
+  private final static String PAYLOAD = "<root><key attribute=\"att\">value</key></root>";
 
   @Test
   public void testGetValue() throws Exception {
@@ -42,12 +42,13 @@ public class AssertXpathEqualsTest extends AssertionCase {
     AssertXpathEquals a  = createAssertion();
     assertTrue(a.execute(new TestMessage(new HashMap<String, String>(),PAYLOAD), new ServiceTestConfig()).isPassed());
   }
+ 
 
   @Test
   public void testExpected(){
     assertEquals("Value [value] at Xpath [/root/key/text()]", createAssertion().expected());
   }
-
+  
   @Test
   public void testGetMessage() throws Exception {
     AssertionResult result  = createAssertion().execute(new TestMessage(new HashMap<String, String>(), PAYLOAD), new ServiceTestConfig());
@@ -57,6 +58,33 @@ public class AssertXpathEqualsTest extends AssertionCase {
   @Test
   public void testShowReturnedMessage(){
     assertTrue(createAssertion().showReturnedMessage());
+  }
+  
+  @Test
+  public void testAttributeExpected(){
+    assertEquals("Value [attribute=\"att\"] at Xpath [/root/key/@attribute]", attributeAssertion().expected());
+  }
+
+  @Test
+  public void testAttributeExecute() throws Exception {
+    AssertXpathEquals a  = attributeAssertion();
+    assertTrue(a.execute(new TestMessage(new HashMap<String, String>(),PAYLOAD), new ServiceTestConfig()).isPassed());
+  }
+  
+  @Test
+  public void testShowAttributeReturnedMessage(){
+    assertTrue(attributeAssertion().showReturnedMessage());
+  }
+  
+  protected AssertXpathEquals attributeAssertion() {
+    AssertXpathEquals a= new AssertXpathEquals();
+    a.setUniqueId("id");
+    a.setValue("attribute=\"att\"");
+    a.setXpath("/root/key/@attribute");
+    Map<String, String> namespace = new HashMap<>();
+    namespace.put("xhtml", "http://www.w3.org/1999/xhtml");
+    a.setNamespaceContext(new KeyValuePairSet(namespace));
+    return a;
   }
 
   @Override


### PR DESCRIPTION
## Motivation

Why am I doing this

Up until now if an attribute was searched for in the Xpath assertions the result would be a stacktrace stating it was an 'unsupported kind of start node (2)' that needed to be changed. Xpath common was written in a way that could only handle nodes and not their attributes.

## Modification

What did I change

The selectSingleNode method has been updated to return the result differently if it is an the user is querying attribute.

## Result

What's the end result for the user

The user can create single attribute assertions

## Testing

How can I test this if I'm reviewing this.

The unit tests in the project are passing when the tests are being run and when the project is built and used in an adapter project with something like this:

##### Test
```xml
<bookstore>
  <book>
    <title lang="en">Some title</title>
    <price>29.99</price>
  </book>
</bookstore
```
##### Xpath Attribute
`/bookstore/book/title/@lang`

it will result in the value returned being: `lang="en"`