### PR TITLE
WiremockHelper allow workingDir and set jettyStopTimeout to stop slow tests

### DIFF
--- a/interlok-service-tester-wiremock/src/test/java/com/adaptris/tester/runtime/helpers/wiremock/WireMockHelperTest.java
+++ b/interlok-service-tester-wiremock/src/test/java/com/adaptris/tester/runtime/helpers/wiremock/WireMockHelperTest.java
@@ -23,6 +23,8 @@ import java.io.File;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+
+import com.adaptris.tester.runtime.ServiceTestConfig;
 import org.junit.Test;
 import com.adaptris.core.ExampleConfigCase;
 import com.adaptris.tester.runtime.helpers.DynamicPortProvider;
@@ -60,7 +62,7 @@ public class WireMockHelperTest extends ExampleConfigCase {
     DynamicPortProvider portProvider = new DynamicPortProvider(8080);
     wireMockHelper.setPortProvider(portProvider);
     wireMockHelper.setFileSource(testFile.getAbsolutePath());
-    wireMockHelper.init();
+    wireMockHelper.init(new ServiceTestConfig());
 
     URL url = new URL("http://localhost:" + portProvider.getPort() + "/hello" );
     URLConnection urlConnection = url.openConnection();
@@ -75,7 +77,7 @@ public class WireMockHelperTest extends ExampleConfigCase {
     }
     assertEquals("{\"hello\": \"world\"}",response.toString());
     assertTrue(wireMockHelper.getHelperProperties().containsKey("wire.mock.helper.port"));
-    assertTrue(8080 <= Integer.valueOf(wireMockHelper.getHelperProperties().get("wire.mock.helper.port")));
+    assertTrue(8080 <= Integer.parseInt(wireMockHelper.getHelperProperties().get("wire.mock.helper.port")));
     in.close();
     wireMockHelper.close();
   }

--- a/interlok-service-tester-wiremock/src/test/java/com/adaptris/tester/runtime/helpers/wiremock/WireMockHelperTest.java
+++ b/interlok-service-tester-wiremock/src/test/java/com/adaptris/tester/runtime/helpers/wiremock/WireMockHelperTest.java
@@ -18,13 +18,17 @@ package com.adaptris.tester.runtime.helpers.wiremock;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 
 import com.adaptris.tester.runtime.ServiceTestConfig;
+import com.adaptris.tester.runtime.ServiceTestException;
 import org.junit.Test;
 import com.adaptris.core.ExampleConfigCase;
 import com.adaptris.tester.runtime.helpers.DynamicPortProvider;
@@ -80,6 +84,20 @@ public class WireMockHelperTest extends ExampleConfigCase {
     assertTrue(8080 <= Integer.parseInt(wireMockHelper.getHelperProperties().get("wire.mock.helper.port")));
     in.close();
     wireMockHelper.close();
+  }
+
+  @Test
+  public void testSyntaxError() throws Exception {
+    WireMockHelper wireMockHelper = new WireMockHelper();
+    DynamicPortProvider portProvider = new DynamicPortProvider(8080);
+    wireMockHelper.setPortProvider(portProvider);
+    wireMockHelper.setFileSource("invalid://uri^");
+    try {
+      wireMockHelper.init(new ServiceTestConfig());
+      fail();
+    } catch (ServiceTestException e){
+      assertTrue(e.getCause() instanceof URISyntaxException);
+    }
   }
 
   protected Helper createHelper() {

--- a/interlok-service-tester-wiremock/src/test/java/com/adaptris/tester/runtime/helpers/wiremock/WireMockHelperTest.java
+++ b/interlok-service-tester-wiremock/src/test/java/com/adaptris/tester/runtime/helpers/wiremock/WireMockHelperTest.java
@@ -12,29 +12,29 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.helpers.wiremock;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 
+import org.junit.Test;
+
+import com.adaptris.interlok.junit.scaffolding.ExampleConfigGenerator;
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.ServiceTestException;
-import org.junit.Test;
-import com.adaptris.core.ExampleConfigCase;
 import com.adaptris.tester.runtime.helpers.DynamicPortProvider;
 import com.adaptris.tester.runtime.helpers.Helper;
 
-public class WireMockHelperTest extends ExampleConfigCase {
+public class WireMockHelperTest extends ExampleConfigGenerator {
   public static final String BASE_DIR_KEY = "HelperCase.baseDir";
 
   public WireMockHelperTest() {
@@ -60,12 +60,12 @@ public class WireMockHelperTest extends ExampleConfigCase {
   @Test
   public void testGet() throws Exception{
     final String serviceFile = "http_stubs";
-    File testFile = new File(this.getClass().getClassLoader().getResource(serviceFile).getFile());
+    URL testFile = this.getClass().getClassLoader().getResource(serviceFile).toURI().toURL();
 
     WireMockHelper wireMockHelper = new WireMockHelper();
     DynamicPortProvider portProvider = new DynamicPortProvider(8080);
     wireMockHelper.setPortProvider(portProvider);
-    wireMockHelper.setFileSource(testFile.getAbsolutePath());
+    wireMockHelper.setFileSource(testFile.toString());
     wireMockHelper.init(new ServiceTestConfig());
 
     URL url = new URL("http://localhost:" + portProvider.getPort() + "/hello" );
@@ -92,12 +92,10 @@ public class WireMockHelperTest extends ExampleConfigCase {
     DynamicPortProvider portProvider = new DynamicPortProvider(8080);
     wireMockHelper.setPortProvider(portProvider);
     wireMockHelper.setFileSource("invalid://uri^");
-    try {
-      wireMockHelper.init(new ServiceTestConfig());
-      fail();
-    } catch (ServiceTestException e){
-      assertTrue(e.getCause() instanceof URISyntaxException);
-    }
+
+    ServiceTestException exception = assertThrows(ServiceTestException.class,
+        () -> wireMockHelper.init(new ServiceTestConfig()));
+    assertTrue(exception.getCause() instanceof URISyntaxException);
   }
 
   protected Helper createHelper() {
@@ -108,8 +106,4 @@ public class WireMockHelperTest extends ExampleConfigCase {
     return wireMockHelper;
   }
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
 }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/ServiceTest.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/ServiceTest.java
@@ -89,9 +89,9 @@ public class ServiceTest implements TestComponent {
     this.workingDirectory = workingDirectory;
   }
 
-  private void initHelpers() throws ServiceTestException {
+  private void initHelpers(ServiceTestConfig config) throws ServiceTestException {
     for(Helper helper : getHelpers()){
-      helper.init();
+      helper.init(config);
     }
   }
 
@@ -123,8 +123,9 @@ public class ServiceTest implements TestComponent {
   }
 
   public JUnitReportTestResults execute() throws ServiceTestException {
-    initHelpers();
-    ServiceTestConfig config = new ServiceTestConfig().withHelperProperties(getHelperProperties()).withWorkingDirectory(getWorkingDirectory());
+    ServiceTestConfig config = new ServiceTestConfig().withWorkingDirectory(getWorkingDirectory());
+    initHelpers(config);
+    config.withHelperProperties(getHelperProperties());
     try (TestClient t = testClient.init(config)) {
       JUnitReportTestResults results = new JUnitReportTestResults(uniqueId);
       for(TestList tests : getTestLists()){

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/ServiceTest.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/ServiceTest.java
@@ -89,14 +89,14 @@ public class ServiceTest implements TestComponent {
     this.workingDirectory = workingDirectory;
   }
 
-  private void initHelpers(ServiceTestConfig config) throws ServiceTestException {
+  void initHelpers(ServiceTestConfig config) throws ServiceTestException {
     for(Helper helper : getHelpers()){
       helper.init(config);
     }
   }
 
   @SuppressWarnings("deprecation")
-  public void closeHelpers()  {
+  void closeHelpers()  {
     for(Helper helper : getHelpers()){
       IOUtils.closeQuietly(helper);
     }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/helpers/Helper.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/helpers/Helper.java
@@ -17,11 +17,13 @@
 package com.adaptris.tester.runtime.helpers;
 
 
+import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.ServiceTestException;
 import com.adaptris.tester.runtime.messages.TestMessage;
 import com.thoughtworks.xstream.annotations.XStreamOmitField;
 
 import java.io.Closeable;
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -43,9 +45,10 @@ public abstract class Helper implements Closeable {
   /**
    * Implementations initialise service so its usable in tests, all properties for connectivity should also be set
    * using {@link #addHelperProperty(String, String)}.
+   * @param config The service tester config
    * @throws ServiceTestException
    */
-  public abstract void init() throws ServiceTestException;
+  public abstract void init(ServiceTestConfig config) throws ServiceTestException;
 
   /**
    * Helper properties should be set during initialisation, they are resolved in the service config.

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/ServiceTestTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/ServiceTestTest.java
@@ -16,8 +16,10 @@
 
 package com.adaptris.tester.runtime;
 
+import java.io.IOException;
 import java.util.Collections;
 import com.adaptris.tester.STExampleConfigCase;
+import com.adaptris.tester.runtime.helpers.Helper;
 import com.adaptris.tester.runtime.messages.TestMessageProvider;
 import com.adaptris.tester.runtime.messages.assertion.AssertMetadataContains;
 import com.adaptris.tester.runtime.messages.metadata.EmptyMetadataProvider;
@@ -25,10 +27,38 @@ import com.adaptris.tester.runtime.messages.payload.InlinePayloadProvider;
 import com.adaptris.tester.runtime.services.ServiceToTest;
 import com.adaptris.tester.runtime.services.sources.InlineSource;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 /**
  * @author mwarman
  */
 public class ServiceTestTest extends STExampleConfigCase {
+
+  @org.junit.Test
+  public void serviceTestHelpers() throws Exception{
+    ServiceTest serviceTest = new ServiceTest();
+    serviceTest.setHelpers(Collections.singletonList(new StubHelper()));
+    assertEquals(1, serviceTest.getHelpers().size());
+    assertTrue(serviceTest.getHelpers().get(0) instanceof StubHelper);
+    serviceTest.initHelpers(new ServiceTestConfig());
+    assertTrue(serviceTest.getHelperProperties().containsKey("test"));
+    assertEquals("value", serviceTest.getHelperProperties().get("test"));
+    serviceTest.closeHelpers();
+  }
+
+  private static class StubHelper extends Helper {
+
+    @Override
+    public void init(ServiceTestConfig config) throws ServiceTestException {
+      addHelperProperty("test", "value");
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+  }
 
   @Override
   protected Object retrieveObjectForSampleConfig() {


### PR DESCRIPTION
## Motivation

Wiremock needed some love to allow for usage in service-tester 

## Modification

- Added the ability to use `service.tester.working.directory` in file-source (INTERLOK-3533)
- Set a jetty stop timeout on wiremock server, to remove "hanging" tests (INTERLOK-3532)

## Result

Quicker tests and ability to set file paths the same as other places in st.

## Testing

./src/main/interlok/config/adapter.xml

```xml
<adapter>
  <unique-id>cranky-jones</unique-id>
  <start-up-event-imp>com.adaptris.core.event.StandardAdapterStartUpEvent</start-up-event-imp>
  <heartbeat-event-imp>com.adaptris.core.HeartbeatEvent</heartbeat-event-imp>
  <shared-components>
    <connections/>
    <services>
      <apache-http-request-service>
        <unique-id>http-get</unique-id>
        <url>${url}/hello</url>
        <content-type>text/plain</content-type>
        <method>GET</method>
        <response-header-handler class="apache-http-discard-response-headers"/>
        <request-header-provider class="apache-http-no-request-headers"/>
        <authenticator class="http-no-authentication"/>
      </apache-http-request-service>
    </services>
  </shared-components>
  <event-handler class="default-event-handler">
    <unique-id>DefaultEventHandler</unique-id>
    <connection class="null-connection">
      <unique-id>big-engelbart</unique-id>
    </connection>
    <producer class="null-message-producer">
      <unique-id>backstabbing-agnesi</unique-id>
    </producer>
  </event-handler>
  <message-error-handler class="null-processing-exception-handler">
    <unique-id>eager-mahavira</unique-id>
  </message-error-handler>
  <failed-message-retrier class="no-retries">
    <unique-id>stoic-meninsky</unique-id>
  </failed-message-retrier>
  <channel-list/>
  <message-error-digester class="standard-message-error-digester">
    <unique-id>ErrorDigest</unique-id>
    <digest-max-size>100</digest-max-size>
  </message-error-digester>
</adapter>
```

./src/test/interlok/config/service-test.xml

```xml
<service-test>
  <unique-id>cranky-ptolemy</unique-id>
  <test-client class="embedded-jmx-test-client">
    <shared-components>
      <connections/>
      <services/>
    </shared-components>
    <shared-components-provider>
      <services/>
    </shared-components-provider>
  </test-client>
  <helpers>
    <wire-mock-helper>
      <file-source>file:///${service.tester.working.directory}/src/test/resources/http_stubs</file-source>
      <port-provider class="dynamic-port-provider" />
    </wire-mock-helper>
  </helpers>
  <test-list>
    <unique-id>cocky-pike</unique-id>
    <test>
      <unique-id>test</unique-id>
      <test-case>
        <unique-id>test-case</unique-id>
        <input-message-provider>
          <metadata-provider class="empty-metadata-provider"/>
          <payload-provider class="empty-payload-provider"/>
        </input-message-provider>
        <assertions>
          <assert-payload-equals>
            <payload><![CDATA[{"hello": "world"}]]></payload>
          </assert-payload-equals>
        </assertions>
      </test-case>
      <service-to-test>
        <source class="default-config-file-source">
          <file>file:///${service.tester.working.directory}/src/main/interlok/config/adapter.xml</file>
        </source>
        <preprocessors>
          <service-unique-id-preprocessor>
            <service>http-get</service>
          </service-unique-id-preprocessor>
          <properties-variable-substitution-preprocessor>
            <properties>
              <key-value-pair>
                <key>url</key>
                <value>http://localhost:${wire.mock.helper.port}</value>
              </key-value-pair>
            </properties>
          </properties-variable-substitution-preprocessor>
        </preprocessors>
      </service-to-test>
    </test>
  </test-list>
</service-test>
```

./src/test/resources/http_stubs/mappings/hello.json

```json
{
  "request" : {
    "url" : "/hello",
    "method" : "GET"
  },
  "response": {
    "status": 200,
    "body": "{\"hello\": \"world\"}",
    "headers": {
        "Content-Type": "application/json"
    }
  }
}
```
