### PR TITLE
INTERLOK-3555 Update the poms urls to point to the right doc page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,35 @@
 # interlok-service-tester
 [![GitHub tag](https://img.shields.io/github/tag/adaptris/interlok-service-tester.svg)](https://github.com/adaptris/interlok-service-tester/tags) ![license](https://img.shields.io/github/license/adaptris/interlok-service-tester.svg) [![codecov](https://codecov.io/gh/adaptris/interlok-service-tester/branch/develop/graph/badge.svg)](https://codecov.io/gh/adaptris/interlok-service-tester) [![Known Vulnerabilities](https://snyk.io/test/github/adaptris/interlok-service-tester/badge.svg?targetFile=build.gradle)](https://snyk.io/test/github/adaptris/interlok-service-tester?targetFile=build.gradle) [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=adaptris/interlok-service-tester)](https://dependabot.com)
 
-The suggested name was `probable-telegram`
+Interlok service tester is a testing framework that allows you to unit test Interlok configurations.
+
+The aim is to remove the need to have working consumers and producers but still be able to test the logic within Interlok configuration, such as branching and mappings.
+
+The output of the execution has also been designed to drop into existing continuous integration cycles.
+
+## Execution
+
+The simplest way to run your service test config is via interlok-boot:
+
+```
+C:\Adaptris\Interlok>java -jar lib\interlok-boot.jar -serviceTest config\service-test.xml
+WARN  [main] [Adapter] [Adapter] has a MessageErrorHandler with no behaviour; messages may be discarded upon exception
+INFO  [main] [Adapter] Adapter Initialised
+INFO  [main] [Adapter] Adapter Started
+INFO  [main] [Test] Running [TestList.Test1]
+INFO  [main] [Test] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 sec
+INFO  [main] [Adapter] stopping adapter [e05d61a7-af13-498b-a669-0b34558afd47] if there are polling loops configured this may take some time
+INFO  [main] [Adapter] Adapter Stopped
+INFO  [main] [Adapter] Adapter Closed
+```
+
+## Arguments
+
+The following arguments are available to customise service tester execution:
+
+- **serviceTest:** Test configuration location
+- **serviceTestOutput:** Output directory for test results (default: ./test-results)
+- **serviceTestPreProcessor:** Pre-processors to execute against test configuration (ex: xinclude)
+
+
+Mor information can be found at https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/

--- a/interlok-service-tester-gradle/build.gradle
+++ b/interlok-service-tester-gradle/build.gradle
@@ -58,13 +58,13 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Experimental Gradle plugin for service-tester")
+		asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         def properties = asNode().appendNode("properties")
-		properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "testing,services,json")
         properties.appendNode("license", "false")
         properties.appendNode("repository", "https://github.com/adaptris/interlok-service-tester")
-		properties.appendNode("readme", "https://raw.githubusercontent.com/adaptris/interlok-service-tester/develop/README.md")
+        properties.appendNode("readme", "https://raw.githubusercontent.com/adaptris/interlok-service-tester/develop/README.md")
      }
     }
   }

--- a/interlok-service-tester-gradle/build.gradle
+++ b/interlok-service-tester-gradle/build.gradle
@@ -59,9 +59,12 @@ publishing {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Experimental Gradle plugin for service-tester")
         def properties = asNode().appendNode("properties")
+		properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "testing,services,json")
         properties.appendNode("license", "false")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-service-tester")
+		properties.appendNode("readme", "https://raw.githubusercontent.com/adaptris/interlok-service-tester/develop/README.md")
      }
     }
   }

--- a/interlok-service-tester-gradle/build.gradle
+++ b/interlok-service-tester-gradle/build.gradle
@@ -58,7 +58,7 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Experimental Gradle plugin for service-tester")
-		asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         def properties = asNode().appendNode("properties")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "testing,services,json")

--- a/interlok-service-tester-json/build.gradle
+++ b/interlok-service-tester-json/build.gradle
@@ -60,7 +60,7 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "JSON Assertions for service-tester")
-		asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         def properties = asNode().appendNode("properties")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "testing,services,json")

--- a/interlok-service-tester-json/build.gradle
+++ b/interlok-service-tester-json/build.gradle
@@ -61,10 +61,12 @@ publishing {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "JSON Assertions for service-tester")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/service-tester-introduction.html")
+        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "testing,services,json")
         properties.appendNode("license", "false")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-service-tester")
+		properties.appendNode("readme", "https://raw.githubusercontent.com/adaptris/interlok-service-tester/develop/README.md")
       }
     }
   }

--- a/interlok-service-tester-json/build.gradle
+++ b/interlok-service-tester-json/build.gradle
@@ -60,13 +60,13 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "JSON Assertions for service-tester")
+		asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "testing,services,json")
         properties.appendNode("license", "false")
         properties.appendNode("repository", "https://github.com/adaptris/interlok-service-tester")
-		properties.appendNode("readme", "https://raw.githubusercontent.com/adaptris/interlok-service-tester/develop/README.md")
+        properties.appendNode("readme", "https://raw.githubusercontent.com/adaptris/interlok-service-tester/develop/README.md")
       }
     }
   }

--- a/interlok-service-tester-wiremock/build.gradle
+++ b/interlok-service-tester-wiremock/build.gradle
@@ -62,13 +62,13 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Wiremock boostrapper for service-tester")
+		asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "testing,services")
         properties.appendNode("license", "false")
         properties.appendNode("repository", "https://github.com/adaptris/interlok-service-tester")
-		properties.appendNode("readme", "https://raw.githubusercontent.com/adaptris/interlok-service-tester/develop/README.md")
+        properties.appendNode("readme", "https://raw.githubusercontent.com/adaptris/interlok-service-tester/develop/README.md")
       }
     }
   }

--- a/interlok-service-tester-wiremock/build.gradle
+++ b/interlok-service-tester-wiremock/build.gradle
@@ -62,7 +62,7 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Wiremock boostrapper for service-tester")
-		asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         def properties = asNode().appendNode("properties")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "testing,services")

--- a/interlok-service-tester-wiremock/build.gradle
+++ b/interlok-service-tester-wiremock/build.gradle
@@ -63,10 +63,12 @@ publishing {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Wiremock boostrapper for service-tester")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/service-tester-introduction.html")
+        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "testing,services")
         properties.appendNode("license", "false")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-service-tester")
+		properties.appendNode("readme", "https://raw.githubusercontent.com/adaptris/interlok-service-tester/develop/README.md")
       }
     }
   }

--- a/interlok-service-tester-xml/build.gradle
+++ b/interlok-service-tester-xml/build.gradle
@@ -53,7 +53,7 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "XML Assertions for service-tester using xmlunit")
-		asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         def properties = asNode().appendNode("properties")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "testing,services,xmlunit")

--- a/interlok-service-tester-xml/build.gradle
+++ b/interlok-service-tester-xml/build.gradle
@@ -53,13 +53,13 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "XML Assertions for service-tester using xmlunit")
+		asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "testing,services,xmlunit")
         properties.appendNode("license", "false")
         properties.appendNode("repository", "https://github.com/adaptris/interlok-service-tester")
-		properties.appendNode("readme", "https://raw.githubusercontent.com/adaptris/interlok-service-tester/develop/README.md")
+        properties.appendNode("readme", "https://raw.githubusercontent.com/adaptris/interlok-service-tester/develop/README.md")
       }
     }
   }

--- a/interlok-service-tester-xml/build.gradle
+++ b/interlok-service-tester-xml/build.gradle
@@ -54,10 +54,12 @@ publishing {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "XML Assertions for service-tester using xmlunit")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/service-tester-introduction.html")
+        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         properties.appendNode("target", "3.10.0+")
         properties.appendNode("tags", "testing,services,xmlunit")
         properties.appendNode("license", "false")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-service-tester")
+		properties.appendNode("readme", "https://raw.githubusercontent.com/adaptris/interlok-service-tester/develop/README.md")
       }
     }
   }

--- a/interlok-service-tester/build.gradle
+++ b/interlok-service-tester/build.gradle
@@ -51,13 +51,13 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Unit testing framework for Interlok")
+		asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         properties.appendNode("target", "3.5.0+")
         properties.appendNode("tags", "testing,services")
         properties.appendNode("license", "false")
         properties.appendNode("repository", "https://github.com/adaptris/interlok-service-tester")
-		properties.appendNode("readme", "https://raw.githubusercontent.com/adaptris/interlok-service-tester/develop/README.md")
+        properties.appendNode("readme", "https://raw.githubusercontent.com/adaptris/interlok-service-tester/develop/README.md")
       }
     }
   }

--- a/interlok-service-tester/build.gradle
+++ b/interlok-service-tester/build.gradle
@@ -52,10 +52,12 @@ publishing {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Unit testing framework for Interlok")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/service-tester-introduction.html")
+        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         properties.appendNode("target", "3.5.0+")
         properties.appendNode("tags", "testing,services")
         properties.appendNode("license", "false")
+        properties.appendNode("repository", "https://github.com/adaptris/interlok-service-tester")
+		properties.appendNode("readme", "https://raw.githubusercontent.com/adaptris/interlok-service-tester/develop/README.md")
       }
     }
   }

--- a/interlok-service-tester/build.gradle
+++ b/interlok-service-tester/build.gradle
@@ -51,7 +51,7 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Unit testing framework for Interlok")
-		asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/service-tester/service-tester-introduction")
         def properties = asNode().appendNode("properties")
         properties.appendNode("target", "3.5.0+")
         properties.appendNode("tags", "testing,services")


### PR DESCRIPTION
## Motivation

The documentation was broken since we changed the doc site

## Modification

- Fix the doc url
- Add a repo url
- Add a readme url
- Add a small readme

## Result

The pom has a correct doc url and a new repo and readme url

## Testing

Check that the new url, repository and readme properties exists in the POM file after running gradle generatePomFileForMavenJavaPublication.
