### PR TITLE
INTERLOK-3559 Remove deprecated and warnings

### DIFF
--- a/interlok-service-tester-gradle/src/main/java/com/adaptris/tester/plugin/ServiceTesterPlugin.java
+++ b/interlok-service-tester-gradle/src/main/java/com/adaptris/tester/plugin/ServiceTesterPlugin.java
@@ -5,6 +5,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 
 public class ServiceTesterPlugin implements Plugin<Project> {
+
   @Override
   public void apply(Project project) {
     Task tester = project.getTasks().create("interlokServiceTester", ServiceTesterTask.class);

--- a/interlok-service-tester-gradle/src/main/java/com/adaptris/tester/plugin/ServiceTesterReportTask.java
+++ b/interlok-service-tester-gradle/src/main/java/com/adaptris/tester/plugin/ServiceTesterReportTask.java
@@ -1,14 +1,17 @@
 package com.adaptris.tester.plugin;
 
+import java.io.File;
+
 import org.apache.tools.ant.taskdefs.XSLTProcess;
 import org.apache.tools.ant.taskdefs.optional.junit.AggregateTransformer;
 import org.apache.tools.ant.taskdefs.optional.junit.XMLResultAggregator;
 import org.apache.tools.ant.types.FileSet;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.tasks.*;
-
-import java.io.File;
-
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
 
 public class ServiceTesterReportTask extends DefaultTask {
 

--- a/interlok-service-tester-gradle/src/test/java/com/adaptris/tester/plugin/ServiceTesterTaskTest.java
+++ b/interlok-service-tester-gradle/src/test/java/com/adaptris/tester/plugin/ServiceTesterTaskTest.java
@@ -1,18 +1,20 @@
 package com.adaptris.tester.plugin;
 
-import com.adaptris.core.stubs.TempFileUtils;
-import com.adaptris.util.GuidGenerator;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
+import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Test;
 
-import java.io.File;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import com.adaptris.core.stubs.TempFileUtils;
+import com.adaptris.util.GuidGenerator;
 
 public class ServiceTesterTaskTest {
 
@@ -51,7 +53,7 @@ public class ServiceTesterTaskTest {
     assertTrue(expectedFile.exists());
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings("deprecation")
   @Test
   public void onlyIf() throws Exception {
     final String serviceFile = "simple_sample.xml";
@@ -62,11 +64,11 @@ public class ServiceTesterTaskTest {
     ServiceTesterTask task = project.getTasks().create("interlokServiceTester", ServiceTesterTask.class);
     task.setServiceTest(testFile);
     task.setServiceTestOutput(tempDir);
-    Spec onlyIf =  task.getOnlyIf();
+    Spec<? super TaskInternal> onlyIf = task.getOnlyIf();
     assertTrue(onlyIf.isSatisfiedBy(task));
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings("deprecation")
   @Test
   public void onlyIfMissing() throws Exception {
     final String serviceFile = "simple_sample1.xml";
@@ -77,7 +79,7 @@ public class ServiceTesterTaskTest {
     ServiceTesterTask task = project.getTasks().create("interlokServiceTester", ServiceTesterTask.class);
     task.setServiceTest(testFile);
     task.setServiceTestOutput(tempDir);
-    Spec onlyIf =  task.getOnlyIf();
+    Spec<? super TaskInternal> onlyIf = task.getOnlyIf();
     assertFalse(onlyIf.isSatisfiedBy(task));
   }
 }

--- a/interlok-service-tester-json/src/test/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPathEqualsTest.java
+++ b/interlok-service-tester-json/src/test/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPathEqualsTest.java
@@ -12,24 +12,24 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.messages.assertion.json;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import java.io.File;
+
 import java.util.HashMap;
+
 import org.junit.Test;
-import com.adaptris.core.ExampleConfigCase;
+
+import com.adaptris.interlok.junit.scaffolding.ExampleConfigGenerator;
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.ServiceTestException;
 import com.adaptris.tester.runtime.messages.TestMessage;
-import com.adaptris.tester.runtime.messages.assertion.Assertion;
 import com.adaptris.tester.runtime.messages.assertion.AssertionResult;
 
-@SuppressWarnings("deprecation")
-public class AssertJsonPathEqualsTest extends ExampleConfigCase {
+public class AssertJsonPathEqualsTest extends ExampleConfigGenerator {
 
   private static final String JSON_PATH = "$.store.bicycle.color";
 
@@ -49,16 +49,14 @@ public class AssertJsonPathEqualsTest extends ExampleConfigCase {
 
   @Override
   protected Object retrieveObjectForSampleConfig() {
-    Assertion assertion = createAssertion();
-    assertion.setUniqueId(null);
-    return assertion;
+    return createAssertion();
   }
 
   @Test
   public void testExecute() throws Exception {
     assertTrue(
         createAssertion().execute(new TestMessage(new HashMap<String, String>(), sampleJsonContent()), new ServiceTestConfig())
-            .isPassed());
+        .isPassed());
     assertFalse(createAssertion().withValue("blue")
         .execute(new TestMessage(new HashMap<String, String>(), sampleJsonContent()), new ServiceTestConfig()).isPassed());
 
@@ -76,7 +74,6 @@ public class AssertJsonPathEqualsTest extends ExampleConfigCase {
 
   @Test
   public void testGetMessage() throws Exception{
-    File file = new File(this.getClass().getClassLoader().getResource("test.json").getFile());
     AssertionResult result = createAssertion().withValue("blue")
         .execute(new TestMessage(new HashMap<String, String>(), sampleJsonContent()), new ServiceTestConfig());
     assertTrue(result.getMessage().contains("assert-jsonpath-equals"));
@@ -91,11 +88,6 @@ public class AssertJsonPathEqualsTest extends ExampleConfigCase {
     return new AssertJsonPathEquals().withValue("red").withJsonPath(JSON_PATH);
   }
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
-  
   public static String sampleJsonContent() {
     return "{\"store\": {\"bicycle\": {\"color\": \"red\",\"price\": 19.95}}}";
   }

--- a/interlok-service-tester-json/src/test/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPayloadEqualsFileTest.java
+++ b/interlok-service-tester-json/src/test/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPayloadEqualsFileTest.java
@@ -12,31 +12,32 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.messages.assertion.json;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.util.HashMap;
+
 import org.junit.Test;
-import com.adaptris.core.ExampleConfigCase;
+
+import com.adaptris.interlok.junit.scaffolding.ExampleConfigGenerator;
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.messages.TestMessage;
 import com.adaptris.tester.runtime.messages.assertion.Assertion;
 import com.adaptris.tester.runtime.messages.assertion.AssertionResult;
 
-@SuppressWarnings("deprecation")
-public class AssertJsonPayloadEqualsFileTest extends ExampleConfigCase {
+public class AssertJsonPayloadEqualsFileTest extends ExampleConfigGenerator {
 
   public AssertJsonPayloadEqualsFileTest() {
     if (PROPERTIES.getProperty(BASE_DIR_KEY) != null) {
       setBaseDir(PROPERTIES.getProperty(BASE_DIR_KEY));
     }
   }
-
 
   @Override
   protected String createExampleXml(Object object) throws Exception {
@@ -45,14 +46,10 @@ public class AssertJsonPayloadEqualsFileTest extends ExampleConfigCase {
     return result;
   }
 
-
   @Override
   protected Object retrieveObjectForSampleConfig() {
-    Assertion assertion = createAssertion();
-    assertion.setUniqueId(null);
-    return assertion;
+    return createAssertion();
   }
-
 
   @Test
   public void testExecute() throws Exception {
@@ -81,10 +78,5 @@ public class AssertJsonPayloadEqualsFileTest extends ExampleConfigCase {
 
   protected Assertion createAssertion() {
     return new AssertJsonPayloadEqualsFile("file:///./message.json");
-  }
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
   }
 }

--- a/interlok-service-tester-json/src/test/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPayloadEqualsTest.java
+++ b/interlok-service-tester-json/src/test/java/com/adaptris/tester/runtime/messages/assertion/json/AssertJsonPayloadEqualsTest.java
@@ -12,16 +12,19 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.messages.assertion.json;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
 import java.util.HashMap;
+
 import org.junit.Test;
-import com.adaptris.core.ExampleConfigCase;
+
+import com.adaptris.interlok.junit.scaffolding.ExampleConfigGenerator;
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.messages.TestMessage;
 import com.adaptris.tester.runtime.messages.assertion.Assertion;
@@ -31,15 +34,13 @@ import com.adaptris.tester.runtime.messages.assertion.PayloadAssertion;
 /**
  * @author mwarman
  */
-@SuppressWarnings("deprecation")
-public class AssertJsonPayloadEqualsTest extends ExampleConfigCase {
+public class AssertJsonPayloadEqualsTest extends ExampleConfigGenerator {
 
   public AssertJsonPayloadEqualsTest() {
     if (PROPERTIES.getProperty(BASE_DIR_KEY) != null) {
       setBaseDir(PROPERTIES.getProperty(BASE_DIR_KEY));
     }
   }
-
 
   @Override
   protected String createExampleXml(Object object) throws Exception {
@@ -50,11 +51,8 @@ public class AssertJsonPayloadEqualsTest extends ExampleConfigCase {
 
   @Override
   protected Object retrieveObjectForSampleConfig() {
-    Assertion assertion = createAssertion();
-    assertion.setUniqueId(null);
-    return assertion;
+    return createAssertion();
   }
-
 
   @Test
   public void testExecute() throws Exception{
@@ -79,10 +77,5 @@ public class AssertJsonPayloadEqualsTest extends ExampleConfigCase {
 
   protected Assertion createAssertion() {
     return new AssertJsonPayloadEquals("{ \"key\" : \"value\" }");
-  }
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
   }
 }

--- a/interlok-service-tester-wiremock/src/main/java/com/adaptris/tester/runtime/helpers/wiremock/WireMockHelper.java
+++ b/interlok-service-tester-wiremock/src/main/java/com/adaptris/tester/runtime/helpers/wiremock/WireMockHelper.java
@@ -12,9 +12,13 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.helpers.wiremock;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
 
 import com.adaptris.core.CoreException;
 import com.adaptris.tester.runtime.ServiceTestConfig;
@@ -27,13 +31,6 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.common.SingleRootFileSource;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import com.thoughtworks.xstream.annotations.XStreamOmitField;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Helper which starts a WireMock server.
@@ -80,7 +77,7 @@ public class WireMockHelper extends Helper {
     getPortProvider().initPort();
     addHelperProperty(WIRE_MOCK_HELPER_PORT_PROPERTY_NAME, String.valueOf(getPortProvider().getPort()));
     wireMockServer = new WireMockServer(
-      WireMockConfiguration.options()
+        WireMockConfiguration.options()
         .port(getPortProvider().getPort())
         .fileSource(new SingleRootFileSource(getFileFromFileSource(config)))
         .enableBrowserProxying(false)

--- a/interlok-service-tester-wiremock/src/test/java/com/adaptris/tester/runtime/helpers/wiremock/WireMockHelperTest.java
+++ b/interlok-service-tester-wiremock/src/test/java/com/adaptris/tester/runtime/helpers/wiremock/WireMockHelperTest.java
@@ -48,14 +48,12 @@ public class WireMockHelperTest extends ExampleConfigGenerator {
     return createHelper();
   }
 
-
   @Override
   protected String createExampleXml(Object object) throws Exception {
     String result = getExampleCommentHeader(object);
     result = result + configMarshaller.marshal(object);
     return result;
   }
-
 
   @Test
   public void testGet() throws Exception{
@@ -86,6 +84,7 @@ public class WireMockHelperTest extends ExampleConfigGenerator {
     wireMockHelper.close();
   }
 
+  @SuppressWarnings("resource")
   @Test
   public void testSyntaxError() throws Exception {
     WireMockHelper wireMockHelper = new WireMockHelper();

--- a/interlok-service-tester-xml/src/test/java/com/adaptris/tester/runtime/messages/assertion/xmlunit/AssertXmlPayloadEqualsFileTest.java
+++ b/interlok-service-tester-xml/src/test/java/com/adaptris/tester/runtime/messages/assertion/xmlunit/AssertXmlPayloadEqualsFileTest.java
@@ -12,23 +12,25 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.messages.assertion.xmlunit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.util.HashMap;
+
 import org.junit.Test;
-import com.adaptris.core.ExampleConfigCase;
+
+import com.adaptris.interlok.junit.scaffolding.ExampleConfigGenerator;
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.messages.TestMessage;
 import com.adaptris.tester.runtime.messages.assertion.Assertion;
 import com.adaptris.tester.runtime.messages.assertion.AssertionResult;
 
-@SuppressWarnings("deprecation")
-public class AssertXmlPayloadEqualsFileTest extends ExampleConfigCase {
+public class AssertXmlPayloadEqualsFileTest extends ExampleConfigGenerator {
 
   public static final String BASE_DIR_KEY = "AssertionCase.baseDir";
 
@@ -48,9 +50,7 @@ public class AssertXmlPayloadEqualsFileTest extends ExampleConfigCase {
 
   @Override
   protected Object retrieveObjectForSampleConfig() {
-    Assertion assertion = createAssertion();
-    assertion.setUniqueId(null);
-    return assertion;
+    return createAssertion();
   }
 
   @Test
@@ -82,8 +82,4 @@ public class AssertXmlPayloadEqualsFileTest extends ExampleConfigCase {
     return new AssertXmlPayloadEqualsFile("file:///./message.xml");
   }
 
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
 }

--- a/interlok-service-tester-xml/src/test/java/com/adaptris/tester/runtime/messages/assertion/xmlunit/AssertXmlPayloadEqualsTest.java
+++ b/interlok-service-tester-xml/src/test/java/com/adaptris/tester/runtime/messages/assertion/xmlunit/AssertXmlPayloadEqualsTest.java
@@ -12,15 +12,18 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.messages.assertion.xmlunit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
 import java.util.HashMap;
+
 import org.junit.Test;
-import com.adaptris.core.ExampleConfigCase;
+
+import com.adaptris.interlok.junit.scaffolding.ExampleConfigGenerator;
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.messages.TestMessage;
 import com.adaptris.tester.runtime.messages.assertion.AssertPayloadEquals;
@@ -28,8 +31,7 @@ import com.adaptris.tester.runtime.messages.assertion.Assertion;
 import com.adaptris.tester.runtime.messages.assertion.AssertionResult;
 import com.adaptris.tester.runtime.messages.assertion.PayloadAssertion;
 
-@SuppressWarnings("deprecation")
-public class AssertXmlPayloadEqualsTest extends ExampleConfigCase {
+public class AssertXmlPayloadEqualsTest extends ExampleConfigGenerator {
   public static final String BASE_DIR_KEY = "AssertionCase.baseDir";
 
   public AssertXmlPayloadEqualsTest() {
@@ -48,9 +50,7 @@ public class AssertXmlPayloadEqualsTest extends ExampleConfigCase {
 
   @Override
   protected Object retrieveObjectForSampleConfig() {
-    Assertion assertion = createAssertion();
-    assertion.setUniqueId(null);
-    return assertion;
+    return createAssertion();
   }
 
   @Test
@@ -81,10 +81,5 @@ public class AssertXmlPayloadEqualsTest extends ExampleConfigCase {
 
   protected Assertion createAssertion() {
     return new AssertXmlPayloadEquals( "<xml />");
-  }
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
   }
 }

--- a/interlok-service-tester/src/main/java/com/adaptris/taglet/JUnitTaglet.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/taglet/JUnitTaglet.java
@@ -12,13 +12,13 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.taglet;
 
-import jdk.javadoc.doclet.Taglet;
-
 import java.util.Map;
+
+import jdk.javadoc.doclet.Taglet;
 
 /**
  * @author mwarman
@@ -40,10 +40,9 @@ public class JUnitTaglet extends AbstractTaglet {
     return "</code></b>.</p>";
   }
 
-  @SuppressWarnings("unchecked")
-  public static void register(Map tagletMap) {
+  public static void register(Map<String, Taglet> tagletMap) {
     JUnitTaglet tag = new JUnitTaglet();
-    Taglet t = (Taglet) tagletMap.get(tag.getName());
+    Taglet t = tagletMap.get(tag.getName());
     if (t != null) {
       tagletMap.remove(tag.getName());
     }

--- a/interlok-service-tester/src/main/java/com/adaptris/taglet/ServiceTestTaglet.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/taglet/ServiceTestTaglet.java
@@ -12,13 +12,13 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.taglet;
 
-import jdk.javadoc.doclet.Taglet;
-
 import java.util.Map;
+
+import jdk.javadoc.doclet.Taglet;
 
 /**
  * @author mwarman
@@ -40,10 +40,9 @@ public class ServiceTestTaglet extends AbstractTaglet {
     return "</code></b> which is the preferred alternative to the fully qualified classname when building your configuration.</p>";
   }
 
-  @SuppressWarnings("unchecked")
-  public static void register(Map tagletMap) {
+  public static void register(Map<String, Taglet> tagletMap) {
     ServiceTestTaglet tag = new ServiceTestTaglet();
-    Taglet t = (Taglet) tagletMap.get(tag.getName());
+    Taglet t = tagletMap.get(tag.getName());
     if (t != null) {
       tagletMap.remove(tag.getName());
     }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/report/junit/JUnitReportProperty.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/report/junit/JUnitReportProperty.java
@@ -19,8 +19,6 @@ package com.adaptris.tester.report.junit;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 
-import java.util.Map;
-
 /**
  * Child of {@link JUnitReportTestSuite} for storing results.
  *

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/report/junit/JUnitReportTestIssueTyped.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/report/junit/JUnitReportTestIssueTyped.java
@@ -18,7 +18,6 @@ package com.adaptris.tester.report.junit;
 
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
 
-
 /**
  * Abstract implementations used in {@link JUnitReportTestCase} for storing results.
  *

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/ServiceTest.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/ServiceTest.java
@@ -12,18 +12,21 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.commons.io.IOUtils;
+
 import com.adaptris.tester.report.junit.JUnitReportTestResults;
 import com.adaptris.tester.runtime.clients.TestClient;
 import com.adaptris.tester.runtime.helpers.Helper;
@@ -37,7 +40,7 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
  * @service-test-config service-test
  */
 @XStreamAlias("service-test")
-public class ServiceTest implements TestComponent {
+public class ServiceTest implements UniqueIdAwareTestComponent {
 
   private String uniqueId;
 
@@ -95,10 +98,9 @@ public class ServiceTest implements TestComponent {
     }
   }
 
-  @SuppressWarnings("deprecation")
   void closeHelpers()  {
     for(Helper helper : getHelpers()){
-      IOUtils.closeQuietly(helper);
+      IOUtils.closeQuietly(helper, null);
     }
   }
 

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/Test.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/Test.java
@@ -12,7 +12,7 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime;
 
@@ -20,8 +20,10 @@ import java.math.RoundingMode;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 import com.adaptris.tester.report.junit.JUnitReportTestSuite;
 import com.adaptris.tester.runtime.clients.TestClient;
 import com.adaptris.tester.runtime.services.ServiceToTest;
@@ -34,7 +36,7 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
  * @service-test-config test
  */
 @XStreamAlias("test")
-public class Test implements TestComponent {
+public class Test implements UniqueIdAwareTestComponent {
 
   private transient Logger log = LoggerFactory.getLogger(this.getClass().getName());
 

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/TestCase.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/TestCase.java
@@ -12,11 +12,12 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
+
 import com.adaptris.tester.report.junit.JUnitReportError;
 import com.adaptris.tester.report.junit.JUnitReportFailure;
 import com.adaptris.tester.report.junit.JUnitReportSkipped;
@@ -34,7 +35,7 @@ import com.thoughtworks.xstream.annotations.XStreamOmitField;
  * @service-test-config test-case
  */
 @XStreamAlias("test-case")
-public class TestCase implements TestComponent {
+public class TestCase implements UniqueIdAwareTestComponent {
 
   private static final String TEST_FILTER =  "test.glob.filter";
 
@@ -106,7 +107,7 @@ public class TestCase implements TestComponent {
 
   public JUnitReportTestCase execute(String parentId, TestClient client, ServiceToTest serviceToTest,
       ServiceTestConfig config)
-      throws ServiceTestException {
+          throws ServiceTestException {
     final String fqName = parentId + "." + getUniqueId();
 
     JUnitReportTestCase result = new JUnitReportTestCase(getUniqueId());

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/TestComponent.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/TestComponent.java
@@ -20,10 +20,4 @@ package com.adaptris.tester.runtime;
  * Base interface for all test components.
  */
 public interface TestComponent {
-
-  /**
-   * Return the unique id.
-   * @return The unique id
-   */
-  String getUniqueId();
 }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/TestList.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/TestList.java
@@ -12,7 +12,7 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime;
 
@@ -20,7 +20,6 @@ import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import com.adaptris.tester.report.junit.JUnitReportTestSuite;
 import com.adaptris.tester.report.junit.JUnitReportTestSuites;
@@ -33,7 +32,7 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
  * @service-test-config test-list
  */
 @XStreamAlias("test-list")
-public class TestList extends AbstractCollection<Test> implements TestComponent {
+public class TestList extends AbstractCollection<Test> implements UniqueIdAwareTestComponent {
 
   private String uniqueId;
   @XStreamImplicit

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/UniqueIdAwareTestComponent.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/UniqueIdAwareTestComponent.java
@@ -1,0 +1,14 @@
+package com.adaptris.tester.runtime;
+
+/**
+ * Base interface for all test components with uniqueId.
+ */
+public interface UniqueIdAwareTestComponent extends TestComponent {
+
+  /**
+   * Return the unique id.
+   *
+   * @return The unique id
+   */
+  String getUniqueId();
+}

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/clients/JMXTestClient.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/clients/JMXTestClient.java
@@ -12,21 +12,24 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.clients;
 
 import static com.adaptris.core.runtime.AdapterComponentCheckerMBean.COMPONENT_CHECKER_TYPE;
 import static com.adaptris.core.runtime.AdapterComponentMBean.ADAPTER_PREFIX;
 import static com.adaptris.core.runtime.AdapterComponentMBean.ID_PREFIX;
+
 import java.io.IOException;
 import java.util.Set;
+
 import javax.management.InstanceNotFoundException;
 import javax.management.JMX;
 import javax.management.MBeanServerConnection;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectInstance;
 import javax.management.ObjectName;
+
 import com.adaptris.core.CoreException;
 import com.adaptris.core.runtime.AdapterComponentChecker;
 import com.adaptris.core.runtime.AdapterComponentCheckerMBean;
@@ -107,9 +110,10 @@ public abstract class JMXTestClient implements TestClient {
     ObjectName patternName = ObjectName.getInstance(interlokBaseObject);
     Set<ObjectInstance> instances = mBeanServer.queryMBeans(patternName, null);
 
-    if (instances.size() == 0)
+    if (instances.size() == 0) {
       throw new InstanceNotFoundException("No configured Adapters");
-    else
+    } else {
       return instances.iterator().next().getObjectName();
+    }
   }
 }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/clients/TestClient.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/clients/TestClient.java
@@ -12,12 +12,13 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.clients;
 
 
 import java.io.Closeable;
+
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.ServiceTestException;
 import com.adaptris.tester.runtime.messages.TestMessage;
@@ -32,11 +33,11 @@ public interface TestClient extends Closeable {
    * <p>
    * Test client initialisation includes configuring and connecting to client needed in {@link #applyService(String, TestMessage)}.
    * </p>
-   * 
+   *
    * @return an initialised TestClient instance for try-with-resources...
    * @throws ServiceTestException wrapping any thrown exception
    */
-  <T extends TestClient> T init(ServiceTestConfig config) throws ServiceTestException;
+  TestClient init(ServiceTestConfig config) throws ServiceTestException;
 
   /**
    * Apply the service to the input message and return outputted message.

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/helpers/Helper.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/helpers/Helper.java
@@ -12,20 +12,18 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.helpers;
 
 
-import com.adaptris.tester.runtime.ServiceTestConfig;
-import com.adaptris.tester.runtime.ServiceTestException;
-import com.adaptris.tester.runtime.messages.TestMessage;
-import com.thoughtworks.xstream.annotations.XStreamOmitField;
-
 import java.io.Closeable;
-import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+
+import com.adaptris.tester.runtime.ServiceTestConfig;
+import com.adaptris.tester.runtime.ServiceTestException;
+import com.thoughtworks.xstream.annotations.XStreamOmitField;
 
 /**
  * Abstract class for helper implementation.

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/MessageException.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/MessageException.java
@@ -12,11 +12,13 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.messages;
 
 public class MessageException extends Exception {
+
+  private static final long serialVersionUID = 4932128208115808069L;
 
   public MessageException(String message, Exception e){
     super(message, e);

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/TestMessageProvider.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/TestMessageProvider.java
@@ -16,7 +16,6 @@
 
 package com.adaptris.tester.runtime.messages;
 
-import com.adaptris.tester.runtime.ServiceTest;
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.messages.metadata.EmptyMetadataProvider;
 import com.adaptris.tester.runtime.messages.metadata.MetadataProvider;

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertAlwaysFail.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertAlwaysFail.java
@@ -31,10 +31,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("assert-always-fail")
 public class AssertAlwaysFail implements Assertion {
 
-  @Deprecated
-  private String uniqueId;
   private Boolean showReturnedMessage;
-
 
   @Override
   public AssertionResult execute(TestMessage actual, ServiceTestConfig config) throws ServiceTestException {

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertLinePayloadEquals.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertLinePayloadEquals.java
@@ -21,9 +21,6 @@ import com.thoughtworks.xstream.annotations.XStreamImplicit;
 @XStreamAlias("assert-line-payload-equals")
 public class AssertLinePayloadEquals implements Assertion {
 
-  @Deprecated
-  private String uniqueId;
-
   @XStreamImplicit(itemFieldName = "line")
   private List<String> expectedLines;
 

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyImpl.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertMetadataKeyImpl.java
@@ -18,8 +18,6 @@ package com.adaptris.tester.runtime.messages.assertion;
 
 public abstract class AssertMetadataKeyImpl implements Assertion {
 
-  @Deprecated
-  private String uniqueId;
   private String key;
 
   public AssertMetadataKeyImpl(){

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertNextServiceId.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertNextServiceId.java
@@ -29,8 +29,6 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("assert-next-service-id")
 public class AssertNextServiceId implements Assertion {
 
-  @Deprecated
-  private String uniqueId;
   private String value;
 
   @Override

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertPayloadEqualsFile.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertPayloadEqualsFile.java
@@ -36,8 +36,6 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("assert-payload-equals-file")
 public class AssertPayloadEqualsFile implements Assertion {
 
-  @Deprecated
-  private String uniqueId;
   private String file;
 
   public AssertPayloadEqualsFile(){

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathBoolean.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathBoolean.java
@@ -39,9 +39,6 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("assert-xpath-boolean")
 public class AssertXpathBoolean extends XpathCommon implements Assertion {
 
-  @Deprecated
-  private String uniqueId;
-
   @Override
   public AssertionResult execute(TestMessage actual, ServiceTestConfig config) throws ServiceTestException {
     try {

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathEquals.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathEquals.java
@@ -42,8 +42,6 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @XStreamAlias("assert-xpath-equals")
 public class AssertXpathEquals extends XpathCommon implements Assertion {
 
-  @Deprecated
-  private String uniqueId;
   private String value;
 
   /**

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/Assertion.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/Assertion.java
@@ -29,28 +29,6 @@ import com.adaptris.tester.runtime.messages.TestMessage;
 public interface Assertion extends TestComponent {
 
   /**
-   * Sets the unique id
-   * 
-   * @param uniqueId The unique id
-   * @implNote The default implementation is no-op
-   * @deprecated since 3.10 with no replacement since it adds no value.
-   */
-  @Deprecated
-  default void setUniqueId(String uniqueId) {
-    
-  }
-
-  /**
-   * Default method since setUniqueID is deprecated
-   * 
-   * @implNote The default implementation just returns null
-   */
-  @Override
-  default String getUniqueId() {
-    return null;
-  }
-
-  /**
    * Execute assertion against test message.
    * @param actual Message resulting from text execution
    * @param config Service test config

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/MetadataAssertion.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/MetadataAssertion.java
@@ -33,8 +33,6 @@ import com.adaptris.util.KeyValuePairSet;
  */
 public abstract class MetadataAssertion implements Assertion {
 
-  @Deprecated
-  private String uniqueId;
   @AutoPopulated
   private KeyValuePairSet metadata;
 

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/PayloadAssertion.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/assertion/PayloadAssertion.java
@@ -28,8 +28,6 @@ import com.adaptris.tester.runtime.messages.TestMessage;
  */
 public abstract class PayloadAssertion implements Assertion {
 
-  @Deprecated
-  private String uniqueId;
   @MarshallingCDATA
   private String payload;
 

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/payload/FilePayloadProvider.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/payload/FilePayloadProvider.java
@@ -17,17 +17,11 @@
 package com.adaptris.tester.runtime.messages.payload;
 
 
-import com.adaptris.fs.FsWorker;
-import com.adaptris.fs.NioWorker;
-import com.adaptris.tester.runtime.ServiceTest;
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.messages.MessageException;
 import com.adaptris.tester.utils.FsHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamOmitField;
-
-import java.io.File;
-import java.net.URL;
 
 /**
  *
@@ -49,6 +43,7 @@ public class FilePayloadProvider extends PayloadProvider {
     setFile(file);
   }
 
+  @Override
   public void init(ServiceTestConfig config) throws MessageException{
     try {
       final byte[] fileContents = FsHelper.getFileBytes(file, config);
@@ -68,7 +63,7 @@ public class FilePayloadProvider extends PayloadProvider {
 
   @Override
   public String getPayload(){
-    return this.payload;
+    return payload;
   }
 
   public void setPayload(String payload) {

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/preprocessor/PreprocessorException.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/preprocessor/PreprocessorException.java
@@ -12,11 +12,13 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.services.preprocessor;
 
 public class PreprocessorException extends Exception {
+
+  private static final long serialVersionUID = 7490918327713697484L;
 
   public PreprocessorException(String message){
     super(message);

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/sources/SourceException.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/sources/SourceException.java
@@ -12,11 +12,13 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.services.sources;
 
 public class SourceException extends Exception {
+
+  private static final long serialVersionUID = -6248348247288363055L;
 
   public SourceException(String message, Exception e){
     super(message, e);

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/AssertionsTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/AssertionsTest.java
@@ -12,7 +12,7 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime;
 
@@ -20,9 +20,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+
 import com.adaptris.tester.report.junit.JUnitReportFailure;
 import com.adaptris.tester.report.junit.JUnitReportTestIssue;
 import com.adaptris.tester.runtime.messages.TestMessage;
@@ -36,30 +38,33 @@ public class AssertionsTest extends TCCase {
   @org.junit.Test
   public void testGetAssertions() throws Exception {
     Assertions a = new Assertions();
-    a.addAssertion(new StubAssertion("id", new AssertionResult("type", true), "message"));
+    a.addAssertion(new StubAssertion(new AssertionResult("type", true), "message"));
+
     assertEquals(1, a.size());
-    assertEquals("id", a.getAssertions().get(0).getUniqueId());
+    assertEquals("message", a.getAssertions().get(0).expected());
   }
 
   @org.junit.Test
   public void testExecutePassed() throws Exception {
     Assertions a = new Assertions();
-    a.addAssertion(new StubAssertion("id", new AssertionResult("type", true), "message"));
+    a.addAssertion(new StubAssertion(new AssertionResult("type", true), "message"));
     JUnitReportTestIssue issue = a.execute(new TestMessage(), new ServiceTestConfig());
+
     assertNull(issue);
-    assertEquals("id", a.getAssertions().get(0).getUniqueId());
+    assertEquals("message", a.getAssertions().get(0).expected());
   }
 
   @org.junit.Test
   public void testExecuteFailed() throws Exception {
     Assertions a = new Assertions();
-    a.addAssertion(new StubAssertion("id", new AssertionResult("type", false), "message-1234"));
+    a.addAssertion(new StubAssertion(new AssertionResult("type", false), "message-1234"));
     JUnitReportTestIssue issue = a.execute(new TestMessage(), new ServiceTestConfig());
+
     assertNotNull(issue);
     assertTrue(issue instanceof JUnitReportFailure);
     assertEquals("Assertion Failure: [type]", ((JUnitReportFailure)issue).getMessage());
     assertTrue(((JUnitReportFailure)issue).getText().contains("message-1234"));
-    assertEquals("id", a.getAssertions().get(0).getUniqueId());
+    assertEquals("message-1234", a.getAssertions().get(0).expected());
   }
 
   @org.junit.Test
@@ -67,17 +72,18 @@ public class AssertionsTest extends TCCase {
     Assertions a = new Assertions();
     a.setAssertions(Arrays.asList(
         new Assertion[] {
-            new StubAssertion("id", new AssertionResult("type", true), "message"),
-            new StubAssertion("id", new AssertionResult("type", false), "message-1234")
+            new StubAssertion(new AssertionResult("type", true), "message"),
+            new StubAssertion(new AssertionResult("type", false), "message-1234")
         })
-    );
+        );
     assertEquals(2, a.size());
     JUnitReportTestIssue issue = a.execute(new TestMessage(), new ServiceTestConfig());
+
     assertNotNull(issue);
     assertTrue(issue instanceof JUnitReportFailure);
     assertEquals("Assertion Failure: [type]", ((JUnitReportFailure)issue).getMessage());
     assertTrue(((JUnitReportFailure)issue).getText().contains("message-1234"));
-    assertEquals("id", a.getAssertions().get(0).getUniqueId());
+    assertEquals("message", a.getAssertions().get(0).expected());
   }
 
   @Override
@@ -102,12 +108,10 @@ public class AssertionsTest extends TCCase {
 
   private class StubAssertion implements Assertion{
 
-    private String uniqueId;
     private final AssertionResult result;
     private final String message;
 
-    StubAssertion(String uniqueId, AssertionResult result, String message){
-      this.uniqueId = uniqueId;
+    StubAssertion(AssertionResult result, String message) {
       this.result = result;
       this.message = message;
     }
@@ -125,16 +129,6 @@ public class AssertionsTest extends TCCase {
     @Override
     public boolean showReturnedMessage() {
       return false;
-    }
-
-    @Override
-    public void setUniqueId(String uniqueId) {
-      this.uniqueId = uniqueId;
-    }
-
-    @Override
-    public String getUniqueId() {
-      return uniqueId;
     }
   }
 

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/ExpectedExceptionTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/ExpectedExceptionTest.java
@@ -19,6 +19,7 @@ package com.adaptris.tester.runtime;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+
 import com.adaptris.core.ServiceException;
 import com.adaptris.tester.report.junit.JUnitReportTestIssue;
 import com.adaptris.tester.report.junit.JUnitReportTestIssueTyped;
@@ -63,7 +64,6 @@ public class ExpectedExceptionTest extends TCCase {
   }
 
 
-  @SuppressWarnings("ThrowableInstanceNeverThrown")
   @org.junit.Test
   public void testCheckExpected() throws Exception {
     Exception exception = new ServiceException("required-metadata-not-present");
@@ -72,7 +72,6 @@ public class ExpectedExceptionTest extends TCCase {
     assertNull(result);
   }
 
-  @SuppressWarnings("ThrowableInstanceNeverThrown")
   @org.junit.Test
   public void testCheckExpectedNoMessage() throws Exception {
     Exception exception = new ServiceException("required-metadata-not-present");
@@ -81,7 +80,6 @@ public class ExpectedExceptionTest extends TCCase {
     assertNull(result);
   }
 
-  @SuppressWarnings("ThrowableInstanceNeverThrown")
   @org.junit.Test
   public void testCheckNotExpected() throws Exception {
     Exception exception = new Exception("required-metadata-not-present");
@@ -91,7 +89,6 @@ public class ExpectedExceptionTest extends TCCase {
     assertEquals("failure", result.getType());
   }
 
-  @SuppressWarnings("ThrowableInstanceNeverThrown")
   @org.junit.Test
   public void testCheckMessageNotExpected() throws Exception {
     Exception exception = new ServiceException("does not match");
@@ -101,7 +98,6 @@ public class ExpectedExceptionTest extends TCCase {
     assertEquals("failure", result.getType());
   }
 
-  @SuppressWarnings("ThrowableInstanceNeverThrown")
   @org.junit.Test
   public void testCheckMessageClassNotFound() throws Exception {
     Exception exception = new ServiceException("does not match");

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/TestCaseTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/TestCaseTest.java
@@ -12,19 +12,27 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime;
 
-import com.adaptris.core.BaseCase;
-import com.adaptris.tester.report.junit.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.adaptris.interlok.junit.scaffolding.BaseCase;
+import com.adaptris.tester.report.junit.JUnitReportError;
+import com.adaptris.tester.report.junit.JUnitReportFailure;
+import com.adaptris.tester.report.junit.JUnitReportSkipped;
+import com.adaptris.tester.report.junit.JUnitReportTestCase;
+import com.adaptris.tester.report.junit.JUnitReportTestIssue;
 import com.adaptris.tester.runtime.messages.TestMessage;
 import com.adaptris.tester.runtime.messages.TestMessageProvider;
 import com.adaptris.tester.runtime.services.ServiceToTest;
 import com.adaptris.tester.runtime.services.sources.InlineSource;
 import com.adaptris.tester.stubs.StubClient;
-
-import static org.junit.Assert.*;
 
 public class TestCaseTest extends BaseCase {
 
@@ -227,9 +235,4 @@ public class TestCaseTest extends BaseCase {
     return st;
   }
 
-
-  @Override
-  public boolean isAnnotatedForJunit4() {
-    return true;
-  }
 }

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/helpers/DynamicPortProviderTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/helpers/DynamicPortProviderTest.java
@@ -18,12 +18,12 @@ package com.adaptris.tester.runtime.helpers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 
 public class DynamicPortProviderTest extends PortProviderCase {
 
   private static final int PORT = 8080;
-
 
   @Test
   public void testDefaultOffset(){

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertAlwaysFailTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertAlwaysFailTest.java
@@ -18,13 +18,13 @@ package com.adaptris.tester.runtime.messages.assertion;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
+
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.messages.TestMessage;
 
-@SuppressWarnings("deprecation")
 public class AssertAlwaysFailTest extends AssertionCase {
 
   @Test
@@ -38,12 +38,6 @@ public class AssertAlwaysFailTest extends AssertionCase {
   public void testExpected() throws Exception {
     Assertion a = createAssertion();
     assertEquals("This is expected... Will always fail", a.expected());
-  }
-
-  @Test
-  public void testGetUniqueId() throws Exception {
-    Assertion a = createAssertion();
-    assertNull(a.getUniqueId());
   }
 
   @Test
@@ -61,7 +55,6 @@ public class AssertAlwaysFailTest extends AssertionCase {
   @Override
   protected AssertAlwaysFail createAssertion() {
     AssertAlwaysFail a = new AssertAlwaysFail();
-    a.setUniqueId("id");
     a.setShowReturnedMessage(true);
     return a;
   }

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertNextServiceIdTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertNextServiceIdTest.java
@@ -19,11 +19,12 @@ package com.adaptris.tester.runtime.messages.assertion;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
+
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.messages.TestMessage;
 
-@SuppressWarnings("deprecation")
 public class AssertNextServiceIdTest extends AssertionCase {
 
   @Test
@@ -56,7 +57,6 @@ public class AssertNextServiceIdTest extends AssertionCase {
   @Override
   protected AssertNextServiceId createAssertion() {
     AssertNextServiceId a = new AssertNextServiceId();
-    a.setUniqueId("id");
     a.setValue("next-service");
     return a;
   }

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathBooleanTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathBooleanTest.java
@@ -18,14 +18,16 @@ package com.adaptris.tester.runtime.messages.assertion;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
 import java.util.HashMap;
 import java.util.Map;
+
 import org.junit.Test;
+
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.messages.TestMessage;
 import com.adaptris.util.KeyValuePairSet;
 
-@SuppressWarnings("deprecation")
 public class AssertXpathBooleanTest extends AssertionCase {
 
   private final static String PAYLOAD = "<root><key>value</key></root>";
@@ -56,7 +58,6 @@ public class AssertXpathBooleanTest extends AssertionCase {
   @Override
   protected AssertXpathBoolean createAssertion() {
     AssertXpathBoolean a = new AssertXpathBoolean();
-    a.setUniqueId("id");
     a.setXpath("count(/root/key) = 1");
     Map<String, String> namespace = new HashMap<>();
     namespace.put("xhtml", "http://www.w3.org/1999/xhtml");

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathEqualsTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertXpathEqualsTest.java
@@ -18,14 +18,16 @@ package com.adaptris.tester.runtime.messages.assertion;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
 import java.util.HashMap;
 import java.util.Map;
+
 import org.junit.Test;
+
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.messages.TestMessage;
 import com.adaptris.util.KeyValuePairSet;
 
-@SuppressWarnings("deprecation")
 public class AssertXpathEqualsTest extends AssertionCase {
 
   private final static String PAYLOAD = "<root><key attribute=\"att\">value</key></root>";
@@ -78,7 +80,6 @@ public class AssertXpathEqualsTest extends AssertionCase {
   
   protected AssertXpathEquals attributeAssertion() {
     AssertXpathEquals a= new AssertXpathEquals();
-    a.setUniqueId("id");
     a.setValue("attribute=\"att\"");
     a.setXpath("/root/key/@attribute");
     Map<String, String> namespace = new HashMap<>();
@@ -90,7 +91,6 @@ public class AssertXpathEqualsTest extends AssertionCase {
   @Override
   protected AssertXpathEquals createAssertion() {
     AssertXpathEquals a= new AssertXpathEquals();
-    a.setUniqueId("id");
     a.setValue("value");
     a.setXpath("/root/key/text()");
     Map<String, String> namespace = new HashMap<>();

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertionCase.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/assertion/AssertionCase.java
@@ -12,13 +12,12 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.messages.assertion;
 
 import com.adaptris.tester.STExampleConfigCase;
 
-@SuppressWarnings("deprecation")
 public abstract class AssertionCase extends STExampleConfigCase {
 
   public static final String BASE_DIR_KEY = "AssertionCase.baseDir";
@@ -31,9 +30,7 @@ public abstract class AssertionCase extends STExampleConfigCase {
 
   @Override
   protected Object retrieveObjectForSampleConfig() {
-    Assertion assertion = createAssertion();
-    assertion.setUniqueId(null);
-    return assertion;
+    return createAssertion();
   }
 
   protected abstract Assertion createAssertion();

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/stubs/StubClient.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/stubs/StubClient.java
@@ -12,11 +12,12 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.stubs;
 
 import java.io.IOException;
+
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.ServiceTestException;
 import com.adaptris.tester.runtime.clients.TestClient;
@@ -25,6 +26,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 @XStreamAlias("stub-test-client")
 public class StubClient implements TestClient {
+
   @Override
   public StubClient init(ServiceTestConfig config) throws ServiceTestException {
     return this;


### PR DESCRIPTION
## Motivation

Remove deprecated classes, members and warnings.

## Modification

- Remove deprecated uniqueId where they were not used, in everything but in ServiceTest, TestList, Test and TestCase.
- BaseCase now uses the scaffolding package version. 
- Extends ExampleConfigGenerator instead of ExampleConfigCase for test classes.
- Fixed a few warnings like unused loggers and variables.

## Result

Project is now clean of warnings.

## Testing

The test should pass, the jars should build and should work.
