### PR TITLE
INTERLOK-2219 Add a new MainSource for Tests that will take the value of the ServiceTest ParentSource.

### DIFF
--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/ServiceTest.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/ServiceTest.java
@@ -76,10 +76,20 @@ public class ServiceTest implements UniqueIdAwareTestComponent {
     return testClient;
   }
 
+  /**
+   * The source of the XML configuration
+   *
+   * @return source
+   */
   public ParentSource getSource() {
     return source;
   }
 
+  /**
+   * The source of the XML configuration
+   *
+   * @param source
+   */
   public void setSource(ParentSource source) {
     this.source = source;
   }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/ServiceTestConfig.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/ServiceTestConfig.java
@@ -27,6 +27,12 @@ public class ServiceTestConfig {
     withWorkingDirectory(new File(System.getProperty("user.dir")));
   }
 
+  /**
+   * Add the ServiceTest source to the ServiceTestConfig
+   *
+   * @param source
+   * @return this
+   */
   public ServiceTestConfig withSource(ParentSource source) {
     this.source = source;
     return this;

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/ServiceTestConfig.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/ServiceTestConfig.java
@@ -7,10 +7,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import com.adaptris.tester.runtime.services.sources.ParentSource;
+
 /**
  * @author mwarman
  */
 public class ServiceTestConfig {
+  public ParentSource source;
   public Map<String, String> helperProperties;
   public File workingDirectory;
 
@@ -19,9 +22,14 @@ public class ServiceTestConfig {
   public Properties workingDirectoryProperties;
 
   public ServiceTestConfig(){
-    this.helperProperties = new HashMap<>();
-    this.workingDirectoryProperties = new Properties();
+    helperProperties = new HashMap<>();
+    workingDirectoryProperties = new Properties();
     withWorkingDirectory(new File(System.getProperty("user.dir")));
+  }
+
+  public ServiceTestConfig withSource(ParentSource source) {
+    this.source = source;
+    return this;
   }
 
   public ServiceTestConfig withHelperProperties(Map<String, String> helperProperties){
@@ -33,7 +41,7 @@ public class ServiceTestConfig {
     try {
       if (workingDirectory != null) {
         this.workingDirectory = workingDirectory;
-        this.workingDirectoryProperties.put(SERVICE_TESTER_WORKING_DIRECTORY,
+        workingDirectoryProperties.put(SERVICE_TESTER_WORKING_DIRECTORY,
             new URI(null, workingDirectory.getAbsolutePath(), null).toASCIIString());
       }
     } catch (URISyntaxException e) {

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/TestCase.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/TestCase.java
@@ -143,15 +143,12 @@ public class TestCase implements UniqueIdAwareTestComponent {
     return result;
   }
 
-  private String createRegexFromGlob(String glob)
-  {
+  private String createRegexFromGlob(String glob) {
     String out = "^";
     boolean escaping = false;
-    for(int i = 0; i < glob.length(); ++i)
-    {
+    for (int i = 0; i < glob.length(); ++i) {
       final char c = glob.charAt(i);
-      switch(c)
-      {
+      switch (c) {
         case '*':
           if (escaping){
             out += "*";

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/ServiceToTest.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/ServiceToTest.java
@@ -12,7 +12,7 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.services;
 
@@ -22,6 +22,7 @@ import java.util.List;
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.runtime.services.preprocessor.Preprocessor;
 import com.adaptris.tester.runtime.services.preprocessor.PreprocessorException;
+import com.adaptris.tester.runtime.services.sources.MainSource;
 import com.adaptris.tester.runtime.services.sources.Source;
 import com.adaptris.tester.runtime.services.sources.SourceException;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -37,6 +38,7 @@ public class ServiceToTest {
   private List<Preprocessor> preprocessors;
 
   public ServiceToTest(){
+    setSource(new MainSource());
     setPreprocessors(new ArrayList<Preprocessor>());
   }
 

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/sources/DefaultConfigSource.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/sources/DefaultConfigSource.java
@@ -27,7 +27,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @service-test-config default-config-file-source
  */
 @XStreamAlias("default-config-file-source")
-@ComponentProfile(since = "3.9.3")
+@ComponentProfile(since = "3.9.3", summary = "Default project adapter XML config")
 public class DefaultConfigSource extends FileSource {
 
   private static final String DEFAULT_SRC = "file:///${service.tester.working.directory}/src/main/interlok/config/adapter.xml";

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/sources/FileSource.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/sources/FileSource.java
@@ -16,6 +16,7 @@
 
 package com.adaptris.tester.runtime.services.sources;
 
+import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.adaptris.tester.utils.FsHelper;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -25,6 +26,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @service-test-config file-source
  */
 @XStreamAlias("file-source")
+@ComponentProfile(summary = "A file source for the adapter or service config")
 public class FileSource implements ParentSource {
 
   private String file;
@@ -46,10 +48,20 @@ public class FileSource implements ParentSource {
     }
   }
 
+  /**
+   * Location of the XML configuration file
+   *
+   * @param file
+   */
   public void setFile(String file) {
     this.file = file;
   }
 
+  /**
+   * Location of the XML configuration file
+   *
+   * @return file
+   */
   public String getFile() {
     return file;
   }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/sources/FileSource.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/sources/FileSource.java
@@ -12,7 +12,7 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.services.sources;
 
@@ -25,13 +25,11 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @service-test-config file-source
  */
 @XStreamAlias("file-source")
-public class FileSource implements Source {
-
+public class FileSource implements ParentSource {
 
   private String file;
 
   public FileSource(){
-
   }
 
   public FileSource(String file){

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/sources/InlineSource.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/sources/InlineSource.java
@@ -12,7 +12,7 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.services.sources;
 

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/sources/InlineSource.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/sources/InlineSource.java
@@ -35,10 +35,20 @@ public class InlineSource implements Source {
     return getXml();
   }
 
+  /**
+   * Adapter or Service XML configuration
+   *
+   * @param xml
+   */
   public void setXml(String xml) {
     this.xml = xml;
   }
 
+  /**
+   * Adapter or Service XML configuration
+   *
+   * @return xml
+   */
   public String getXml() {
     return xml;
   }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/sources/MainSource.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/sources/MainSource.java
@@ -17,24 +17,20 @@
 package com.adaptris.tester.runtime.services.sources;
 
 import com.adaptris.annotation.ComponentProfile;
+import com.adaptris.tester.runtime.ServiceTestConfig;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
 /**
- * Extension of {@link FileSource} that simply defaults to
- * {@code file:///${service.tester.working.directory}/src/main/interlok/config/adapter.xml}.
  *
- *
- * @service-test-config default-config-file-source
+ * @service-test-config main-source
  */
-@XStreamAlias("default-config-file-source")
-@ComponentProfile(since = "3.9.3")
-public class DefaultConfigSource extends FileSource {
+@XStreamAlias("main-source")
+@ComponentProfile(since = "4.1.0")
+public class MainSource implements Source {
 
-  private static final String DEFAULT_SRC = "file:///${service.tester.working.directory}/src/main/interlok/config/adapter.xml";
-
-  public DefaultConfigSource(){
-    super();
-    setFile(DEFAULT_SRC);
+  @Override
+  public String getSource(ServiceTestConfig config) throws SourceException {
+    return config.source.getSource(config);
   }
 
 }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/sources/MainSource.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/sources/MainSource.java
@@ -25,7 +25,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
  * @service-test-config main-source
  */
 @XStreamAlias("main-source")
-@ComponentProfile(since = "4.1.0")
+@ComponentProfile(since = "4.1.0", summary = "Use the source defined in ServiceTest")
 public class MainSource implements Source {
 
   @Override

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/sources/ParentSource.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/sources/ParentSource.java
@@ -1,0 +1,4 @@
+package com.adaptris.tester.runtime.services.sources;
+
+public interface ParentSource extends Source {
+}

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/ServiceTestTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/ServiceTestTest.java
@@ -12,12 +12,16 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.util.Collections;
+
 import com.adaptris.tester.STExampleConfigCase;
 import com.adaptris.tester.runtime.helpers.Helper;
 import com.adaptris.tester.runtime.messages.TestMessageProvider;
@@ -25,15 +29,21 @@ import com.adaptris.tester.runtime.messages.assertion.AssertMetadataContains;
 import com.adaptris.tester.runtime.messages.metadata.EmptyMetadataProvider;
 import com.adaptris.tester.runtime.messages.payload.InlinePayloadProvider;
 import com.adaptris.tester.runtime.services.ServiceToTest;
+import com.adaptris.tester.runtime.services.sources.FileSource;
 import com.adaptris.tester.runtime.services.sources.InlineSource;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author mwarman
  */
 public class ServiceTestTest extends STExampleConfigCase {
+
+  @org.junit.Test
+  public void serviceTestSource() throws Exception {
+    ServiceTest serviceTest = new ServiceTest();
+    FileSource source = new FileSource();
+    serviceTest.setSource(source);
+    assertEquals(source, serviceTest.getSource());
+  }
 
   @org.junit.Test
   public void serviceTestHelpers() throws Exception{

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/services/sources/FileSourceTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/services/sources/FileSourceTest.java
@@ -12,16 +12,19 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.services.sources;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+
 import java.io.File;
+
 import org.junit.Test;
 import org.w3c.dom.Document;
+
 import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.core.util.XmlHelper;
 import com.adaptris.tester.runtime.ServiceTestConfig;
@@ -39,15 +42,12 @@ public class FileSourceTest extends SourceCase{
 
   @Test
   public void testGetSourceNoFiles() throws Exception {
-    try {
-      final String testFile = "service.xml";
-      File parentDir = new File(this.getClass().getClassLoader().getResource(testFile).getFile()).getParentFile();
-      Source source = new FileSource("file:///" + parentDir.getAbsolutePath() + "/doesnotexist.xml");
-      source.getSource(new ServiceTestConfig());
-      fail();
-    } catch (SourceException e){
-      assertTrue(e.getMessage().contains("Failed to read file"));
-    }
+    final String testFile = "service.xml";
+    File parentDir = new File(this.getClass().getClassLoader().getResource(testFile).getFile()).getParentFile();
+    Source source = new FileSource("file:///" + parentDir.getAbsolutePath() + "/doesnotexist.xml");
+
+    SourceException e = assertThrows(SourceException.class, () -> source.getSource(new ServiceTestConfig()));
+    assertTrue(e.getMessage().contains("Failed to read file"));
   }
 
   @Test

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/services/sources/MainSourceTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/services/sources/MainSourceTest.java
@@ -1,0 +1,62 @@
+/*
+    Copyright 2018 Adaptris Ltd.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+package com.adaptris.tester.runtime.services.sources;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.junit.Test;
+import org.w3c.dom.Document;
+
+import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
+import com.adaptris.core.util.XmlHelper;
+import com.adaptris.tester.runtime.ServiceTestConfig;
+
+public class MainSourceTest extends SourceCase {
+
+  @Test
+  public void testGetSource() throws Exception {
+    final String serviceFile = "service.xml";
+    File testFile = new File(this.getClass().getClassLoader().getResource(serviceFile).getFile());
+    ParentSource fileSource = new FileSource("file:///" + testFile.getAbsolutePath());
+    Source source = new MainSource();
+    ServiceTestConfig config = new ServiceTestConfig().withSource(fileSource);
+    Document document = XmlHelper.createDocument(source.getSource(config), new DocumentBuilderFactoryBuilder());
+    assertEquals("service-collection", document.getDocumentElement().getNodeName());
+  }
+
+  @Test
+  public void testGetSourceNoFiles() throws Exception {
+    final String testFile = "service.xml";
+    File parentDir = new File(this.getClass().getClassLoader().getResource(testFile).getFile()).getParentFile();
+    ParentSource fileSource = new FileSource("file:///" + parentDir.getAbsolutePath() + "/doesnotexist.xml");
+    Source source = new MainSource();
+    ServiceTestConfig config = new ServiceTestConfig().withSource(fileSource);
+
+    SourceException e = assertThrows(SourceException.class, () -> source.getSource(config));
+    assertTrue(e.getMessage().contains("Failed to read file"));
+  }
+
+  @Override
+  protected Source createSource() {
+    return new MainSource();
+  }
+
+}


### PR DESCRIPTION
## Motivation

When you create a service tester test suite which has many tests. What you find is, that in every test you have to define a 'Source'. As the service tester is mainly made for project this seems very repetitive and if for a reason or another we want to use a different file source we have to change it in every test.

## Modification

- ServiceTest now has a ParentSource that can be a DefaultConfigSource or a FileSource. I didn't make the InlineSource a ParentSource as I'm not sure it makes sense.
- Then a Test can select MainSource as its source (now default). When the test is executed it will get the value of the SeviceTest.source.

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [x] Added supporting annotations (like XStreamAlias / ComponentProfile)
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI
- [x] Checked the display of the component in the UI

## Result

The user can now use the the ParentSource in ServiceTest to specify the adapter XML configuration. In the Test config he will just need to select the MainSource (default value) to use the ParentSource.
However the user can also override the ParentSource by choosing a different source in the Test.

## Testing

- `gradlew clean check jar` should work.

- copy the interlok-service-tester.jar built from this branch into an interlok lib folder
- run java -jar lib\interlok-boot.jar -serviceTest config\service-test.xml on an old service-test.xml and that should work the same as before (pass or fail depending the assertion).
- Edit the service-test.xml and under `<service-test>` add:

```xml
  <source class="default-config-file-source">
    <file>file:///${service.tester.working.directory}/src/main/interlok/config/adapter.xml</file>
  </source>
```
- Change the source in `<service-to-test>` to be `<source class="main-source"/>`
- run java -jar lib\interlok-boot.jar -serviceTest config\service-test.xml on an old service-test.xml and that should work the same as before (pass or fail depending the assertion).

If you want to test it in the UI you will need the changes in https://gitlab.agb.rbxd.ds/interlok/interlok-ui/-/merge_requests/59

- Create a new project in the config page with a couple of service to test.
- Go to the service tester page and create a new service test config.
- Add a new test and a new test case and run it via the UI. The test should pass (or fail depending the assertion)
- Open an existing service test config and make sure it still works.

