### PR TITLE
feature/INTERLOK-3064 - services inside conditions

### DIFF
--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/preprocessor/ServiceUniqueIdPreprocessor.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/preprocessor/ServiceUniqueIdPreprocessor.java
@@ -87,15 +87,21 @@ public class ServiceUniqueIdPreprocessor implements Preprocessor {
   String generateXpath(){
     StringBuilder stringBuilder = new StringBuilder();
     stringBuilder.append("/");
+    boolean extraSlash = false;
     if(getChannel() != null) {
       stringBuilder.append(String.format(CHANNEL_FORMAT, getChannel()));
+      extraSlash = true;
     }
     if(getWorkflow() != null) {
       stringBuilder.append(String.format(WORKFLOW_FORMAT, getWorkflow()));
+      extraSlash = true;
     }
     Iterator<String> services = getServices().iterator();
     while (services.hasNext()){
       String service = services.next();
+      if (extraSlash) {
+        stringBuilder.append("/");
+      }
       stringBuilder.append(String.format(SERVICES_FORMAT, service));
       if(services.hasNext()){
         stringBuilder.append(SERVICES);

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/preprocessor/ServiceUniqueIdPreprocessor.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/preprocessor/ServiceUniqueIdPreprocessor.java
@@ -47,7 +47,7 @@ public class ServiceUniqueIdPreprocessor implements Preprocessor {
   private static final String CHANNEL_FORMAT = "/channel-list/*[unique-id = '%s']";
   private static final String WORKFLOW_FORMAT = "/workflow-list/*[unique-id = '%s']/service-collection/services";
   private static final String SERVICES_FORMAT = "/*[unique-id = '%s']";
-  private static final String SERVICES = "/services";
+  private static final String SERVICES = "/*[self::services or self::case or self::then or self::otherwise]";
 
   private String channel;
   private String workflow;
@@ -87,21 +87,15 @@ public class ServiceUniqueIdPreprocessor implements Preprocessor {
   String generateXpath(){
     StringBuilder stringBuilder = new StringBuilder();
     stringBuilder.append("/");
-    boolean extraSlash = false;
     if(getChannel() != null) {
       stringBuilder.append(String.format(CHANNEL_FORMAT, getChannel()));
-      extraSlash = true;
     }
     if(getWorkflow() != null) {
       stringBuilder.append(String.format(WORKFLOW_FORMAT, getWorkflow()));
-      extraSlash = true;
     }
     Iterator<String> services = getServices().iterator();
     while (services.hasNext()){
       String service = services.next();
-      if (extraSlash) {
-        stringBuilder.append("/");
-      }
       stringBuilder.append(String.format(SERVICES_FORMAT, service));
       if(services.hasNext()){
         stringBuilder.append(SERVICES);

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/services/preprocessor/ServiceUniqueIdPreprocessorTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/services/preprocessor/ServiceUniqueIdPreprocessorTest.java
@@ -12,15 +12,19 @@
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-*/
+ */
 
 package com.adaptris.tester.runtime.services.preprocessor;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
+
 import java.util.Arrays;
 import java.util.Collections;
+
 import org.junit.Test;
+
 import com.adaptris.tester.runtime.ServiceTestConfig;
 
 /**
@@ -46,6 +50,10 @@ public class ServiceUniqueIdPreprocessorTest extends PreprocessorCase {
   private static final String ADAPTER_XML_WITH_CONDITION = "<adapter><channel-list><channel><unique-id>channel</unique-id><workflow-list><standard-workflow><unique-id>workflow</unique-id><service-collection class=\"service-list\"><unique-id>serene-fermi</unique-id><services><switch><unique-id>switch</unique-id><case><condition class=\"metadata\"><operator class=\"metadata-ends-with-ignore-case\"><result-key>comparison-result-json</result-key><value>.json</value><ignore-case>true</ignore-case></operator><metadata-key>originalname</metadata-key></condition><service class=\"service-list\"><unique-id>json-case</unique-id><services><logging-service><unique-id>log-json</unique-id><log-level>DEBUG</log-level><text>Processing JSON file</text></logging-service><add-metadata-service><unique-id>set-metadata-action-json</unique-id><metadata-element><key>action</key><value>json</value></metadata-element></add-metadata-service></services></service></case><case><condition class=\"metadata\"><operator class=\"metadata-ends-with-ignore-case\"><result-key>comparison-result-xml</result-key><value>.xml</value><ignore-case>true</ignore-case></operator><metadata-key>originalname</metadata-key></condition><service class=\"service-list\"><unique-id>xml-case</unique-id><services><logging-service><unique-id>log-xml</unique-id><log-level>DEBUG</log-level><text>Processing XML file</text></logging-service><add-metadata-service><unique-id>set-metadata-action-xml</unique-id><metadata-element><key>action</key><value>xml</value></metadata-element></add-metadata-service></services></service></case><case><condition class=\"case-default\"/><service class=\"service-list\"><unique-id>default-case</unique-id><services><logging-service><unique-id>log-file</unique-id><log-level>DEBUG</log-level><text>Processing unknown file</text></logging-service><add-metadata-service><unique-id>set-metadata-action-default</unique-id><metadata-element><key>action</key><value>default</value></metadata-element></add-metadata-service></services></service></case></switch></services></service-collection></standard-workflow></workflow-list></channel></channel-list></adapter>";
   private static final String SERVICE_IN_CONDITION_1 = "<service class=\"service-list\"><unique-id>json-case</unique-id><services><logging-service><unique-id>log-json</unique-id><log-level>DEBUG</log-level><text>Processing JSON file</text></logging-service><add-metadata-service><unique-id>set-metadata-action-json</unique-id><metadata-element><key>action</key><value>json</value></metadata-element></add-metadata-service></services></service>";
   private static final String SERVICE_IN_CONDITION_2 = "<service class=\"service-list\"><unique-id>xml-case</unique-id><services><logging-service><unique-id>log-xml</unique-id><log-level>DEBUG</log-level><text>Processing XML file</text></logging-service><add-metadata-service><unique-id>set-metadata-action-xml</unique-id><metadata-element><key>action</key><value>xml</value></metadata-element></add-metadata-service></services></service>";
+
+  private static final String ADAPTER_XML_WITH_IF_THEN = "<adapter><channel-list><channel><unique-id>channel</unique-id><workflow-list><standard-workflow><unique-id>workflow</unique-id><service-collection class=\"service-list\"><unique-id>serene-fermi</unique-id><services><if-then-otherwise><unique-id>if-else</unique-id><condition class=\"expression\"><algorithm>%message{myKey} == 1</algorithm></condition><then><logging-service><unique-id>log-if</unique-id><log-level>DEBUG</log-level><text>value of keyKey is 1</text></logging-service></then><otherwise><logging-service><unique-id>log-else</unique-id><log-level>DEBUG</log-level><text>value of keyKey is not 1</text></logging-service></otherwise></if-then-otherwise></services></service-collection></standard-workflow></workflow-list></channel></channel-list></adapter>";
+  private static final String EXPECTED_SERVICE_IN_IF = "<logging-service><unique-id>log-if</unique-id><log-level>DEBUG</log-level><text>value of keyKey is 1</text></logging-service>";
+  private static final String EXPECTED_SERVICE_IN_ELSE = "<logging-service><unique-id>log-else</unique-id><log-level>DEBUG</log-level><text>value of keyKey is not 1</text></logging-service>";
 
   @Test
   public void testExecute() throws Exception{
@@ -91,6 +99,26 @@ public class ServiceUniqueIdPreprocessorTest extends PreprocessorCase {
 
     preprocessor = new ServiceUniqueIdPreprocessor(Arrays.asList("switch", "xml-case"));
     assertEquals(SERVICE_IN_CONDITION_2, preprocessor.execute(ADAPTER_XML_WITH_CONDITION, new ServiceTestConfig()));
+  }
+
+  @Test
+  public void testServiceInIfElse() throws Exception {
+    ServiceUniqueIdPreprocessor preprocessor = new ServiceUniqueIdPreprocessor("channel", "workflow", Arrays.asList("if-else", "log-if"));
+    assertEquals(EXPECTED_SERVICE_IN_IF, preprocessor.execute(ADAPTER_XML_WITH_IF_THEN, new ServiceTestConfig()));
+
+    preprocessor = new ServiceUniqueIdPreprocessor("channel", "workflow", Arrays.asList("if-else", "log-else"));
+    assertEquals(EXPECTED_SERVICE_IN_ELSE, preprocessor.execute(ADAPTER_XML_WITH_IF_THEN, new ServiceTestConfig()));
+  }
+
+  @Test
+  public void testServiceInIfElseCantFindService() throws Exception {
+    // The parent service is missing in the list, won't find anything
+    ServiceUniqueIdPreprocessor preprocessor = new ServiceUniqueIdPreprocessor("channel", "workflow", Arrays.asList("log-else"));
+    PreprocessorException exception = assertThrows(PreprocessorException.class,
+        () -> preprocessor.execute(ADAPTER_XML_WITH_IF_THEN, new ServiceTestConfig()));
+    assertEquals(
+        "Failed to find service: channel: [channel] workflow: [workflow] services: [[log-else]] xpath [//channel-list/*[unique-id = 'channel']/workflow-list/*[unique-id = 'workflow']/service-collection/services/*[unique-id = 'log-else']]",
+        exception.getMessage());
   }
 
   @Test

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/services/preprocessor/ServiceUniqueIdPreprocessorTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/services/preprocessor/ServiceUniqueIdPreprocessorTest.java
@@ -34,11 +34,11 @@ public class ServiceUniqueIdPreprocessorTest extends PreprocessorCase {
   private static final String EXPECTED_MULTI = "<service-list><unique-id>service-2</unique-id><services><add-metadata-service><unique-id>add-metadata</unique-id><metadata-element><key>key2</key><value>value2</value></metadata-element></add-metadata-service></services></service-list>";
   private static final String EXPECTED_MULTI_ADD = "<add-metadata-service><unique-id>add-metadata</unique-id><metadata-element><key>key2</key><value>value2</value></metadata-element></add-metadata-service>";
 
-  private static final String CHANNEL_WORKFLOW_SINGLE_SERVICE_XPATH = "//channel-list/*[unique-id = 'channel-1']/workflow-list/*[unique-id = 'workflow-1']/service-collection/services/*[unique-id = 'service-1']";
-  private static final String CHANNEL_WORKFLOW_MULTI_SERVICE_XPATH = CHANNEL_WORKFLOW_SINGLE_SERVICE_XPATH + "/services/*[unique-id = 'service-2']";
+  private static final String CHANNEL_WORKFLOW_SINGLE_SERVICE_XPATH = "//channel-list/*[unique-id = 'channel-1']/workflow-list/*[unique-id = 'workflow-1']/service-collection/services//*[unique-id = 'service-1']";
+  private static final String CHANNEL_WORKFLOW_MULTI_SERVICE_XPATH = CHANNEL_WORKFLOW_SINGLE_SERVICE_XPATH + "/services//*[unique-id = 'service-2']";
 
-  private static final String WORKFLOW_SINGLE_SERVICE_XPATH = "//workflow-list/*[unique-id = 'workflow-1']/service-collection/services/*[unique-id = 'service-1']";
-  private static final String WORKFLOW_MULTI_SERVICE_XPATH = WORKFLOW_SINGLE_SERVICE_XPATH + "/services/*[unique-id = 'service-2']";
+  private static final String WORKFLOW_SINGLE_SERVICE_XPATH = "//workflow-list/*[unique-id = 'workflow-1']/service-collection/services//*[unique-id = 'service-1']";
+  private static final String WORKFLOW_MULTI_SERVICE_XPATH = WORKFLOW_SINGLE_SERVICE_XPATH + "/services//*[unique-id = 'service-2']";
 
   private static final String SINGLE_SERVICE_XPATH = "//*[unique-id = 'service-1']";
   private static final String MULTI_SERVICE_XPATH = SINGLE_SERVICE_XPATH + "/services/*[unique-id = 'service-2']";
@@ -87,7 +87,7 @@ public class ServiceUniqueIdPreprocessorTest extends PreprocessorCase {
       preprocessor.execute(ADAPTER_XML, new ServiceTestConfig());
       fail();
     } catch (PreprocessorException e) {
-      assertEquals("Failed to find service: channel: [channel-1] workflow: [workflow-1] services: [[service-no-match]] xpath [//channel-list/*[unique-id = 'channel-1']/workflow-list/*[unique-id = 'workflow-1']/service-collection/services/*[unique-id = 'service-no-match']]", e.getMessage());
+      assertEquals("Failed to find service: channel: [channel-1] workflow: [workflow-1] services: [[service-no-match]] xpath [//channel-list/*[unique-id = 'channel-1']/workflow-list/*[unique-id = 'workflow-1']/service-collection/services//*[unique-id = 'service-no-match']]", e.getMessage());
     }
   }
 

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/services/preprocessor/ServiceUniqueIdPreprocessorTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/services/preprocessor/ServiceUniqueIdPreprocessorTest.java
@@ -34,14 +34,14 @@ public class ServiceUniqueIdPreprocessorTest extends PreprocessorCase {
   private static final String EXPECTED_MULTI = "<service-list><unique-id>service-2</unique-id><services><add-metadata-service><unique-id>add-metadata</unique-id><metadata-element><key>key2</key><value>value2</value></metadata-element></add-metadata-service></services></service-list>";
   private static final String EXPECTED_MULTI_ADD = "<add-metadata-service><unique-id>add-metadata</unique-id><metadata-element><key>key2</key><value>value2</value></metadata-element></add-metadata-service>";
 
-  private static final String CHANNEL_WORKFLOW_SINGLE_SERVICE_XPATH = "//channel-list/*[unique-id = 'channel-1']/workflow-list/*[unique-id = 'workflow-1']/service-collection/services//*[unique-id = 'service-1']";
-  private static final String CHANNEL_WORKFLOW_MULTI_SERVICE_XPATH = CHANNEL_WORKFLOW_SINGLE_SERVICE_XPATH + "/services//*[unique-id = 'service-2']";
+  private static final String CHANNEL_WORKFLOW_SINGLE_SERVICE_XPATH = "//channel-list/*[unique-id = 'channel-1']/workflow-list/*[unique-id = 'workflow-1']/service-collection/services/*[unique-id = 'service-1']";
+  private static final String CHANNEL_WORKFLOW_MULTI_SERVICE_XPATH = CHANNEL_WORKFLOW_SINGLE_SERVICE_XPATH + "/*[self::services or self::case or self::then or self::otherwise]/*[unique-id = 'service-2']";
 
-  private static final String WORKFLOW_SINGLE_SERVICE_XPATH = "//workflow-list/*[unique-id = 'workflow-1']/service-collection/services//*[unique-id = 'service-1']";
-  private static final String WORKFLOW_MULTI_SERVICE_XPATH = WORKFLOW_SINGLE_SERVICE_XPATH + "/services//*[unique-id = 'service-2']";
+  private static final String WORKFLOW_SINGLE_SERVICE_XPATH = "//workflow-list/*[unique-id = 'workflow-1']/service-collection/services/*[unique-id = 'service-1']";
+  private static final String WORKFLOW_MULTI_SERVICE_XPATH = WORKFLOW_SINGLE_SERVICE_XPATH + "/*[self::services or self::case or self::then or self::otherwise]/*[unique-id = 'service-2']";
 
   private static final String SINGLE_SERVICE_XPATH = "//*[unique-id = 'service-1']";
-  private static final String MULTI_SERVICE_XPATH = SINGLE_SERVICE_XPATH + "/services/*[unique-id = 'service-2']";
+  private static final String MULTI_SERVICE_XPATH = SINGLE_SERVICE_XPATH + "/*[self::services or self::case or self::then or self::otherwise]/*[unique-id = 'service-2']";
 
   private static final String ADAPTER_XML_WITH_CONDITION = "<adapter><channel-list><channel><unique-id>channel</unique-id><workflow-list><standard-workflow><unique-id>workflow</unique-id><service-collection class=\"service-list\"><unique-id>serene-fermi</unique-id><services><switch><unique-id>switch</unique-id><case><condition class=\"metadata\"><operator class=\"metadata-ends-with-ignore-case\"><result-key>comparison-result-json</result-key><value>.json</value><ignore-case>true</ignore-case></operator><metadata-key>originalname</metadata-key></condition><service class=\"service-list\"><unique-id>json-case</unique-id><services><logging-service><unique-id>log-json</unique-id><log-level>DEBUG</log-level><text>Processing JSON file</text></logging-service><add-metadata-service><unique-id>set-metadata-action-json</unique-id><metadata-element><key>action</key><value>json</value></metadata-element></add-metadata-service></services></service></case><case><condition class=\"metadata\"><operator class=\"metadata-ends-with-ignore-case\"><result-key>comparison-result-xml</result-key><value>.xml</value><ignore-case>true</ignore-case></operator><metadata-key>originalname</metadata-key></condition><service class=\"service-list\"><unique-id>xml-case</unique-id><services><logging-service><unique-id>log-xml</unique-id><log-level>DEBUG</log-level><text>Processing XML file</text></logging-service><add-metadata-service><unique-id>set-metadata-action-xml</unique-id><metadata-element><key>action</key><value>xml</value></metadata-element></add-metadata-service></services></service></case><case><condition class=\"case-default\"/><service class=\"service-list\"><unique-id>default-case</unique-id><services><logging-service><unique-id>log-file</unique-id><log-level>DEBUG</log-level><text>Processing unknown file</text></logging-service><add-metadata-service><unique-id>set-metadata-action-default</unique-id><metadata-element><key>action</key><value>default</value></metadata-element></add-metadata-service></services></service></case></switch></services></service-collection></standard-workflow></workflow-list></channel></channel-list></adapter>";
   private static final String SERVICE_IN_CONDITION_1 = "<service class=\"service-list\"><unique-id>json-case</unique-id><services><logging-service><unique-id>log-json</unique-id><log-level>DEBUG</log-level><text>Processing JSON file</text></logging-service><add-metadata-service><unique-id>set-metadata-action-json</unique-id><metadata-element><key>action</key><value>json</value></metadata-element></add-metadata-service></services></service>";
@@ -86,10 +86,10 @@ public class ServiceUniqueIdPreprocessorTest extends PreprocessorCase {
 
   @Test
   public void testServiceInCondition() throws Exception {
-    ServiceUniqueIdPreprocessor preprocessor = new ServiceUniqueIdPreprocessor("channel", "workflow", Collections.singletonList("json-case"));
+    ServiceUniqueIdPreprocessor preprocessor = new ServiceUniqueIdPreprocessor("channel", "workflow", Arrays.asList("switch", "json-case"));
     assertEquals(SERVICE_IN_CONDITION_1, preprocessor.execute(ADAPTER_XML_WITH_CONDITION, new ServiceTestConfig()));
 
-    preprocessor = new ServiceUniqueIdPreprocessor(Collections.singletonList("xml-case"));
+    preprocessor = new ServiceUniqueIdPreprocessor(Arrays.asList("switch", "xml-case"));
     assertEquals(SERVICE_IN_CONDITION_2, preprocessor.execute(ADAPTER_XML_WITH_CONDITION, new ServiceTestConfig()));
   }
 
@@ -100,7 +100,7 @@ public class ServiceUniqueIdPreprocessorTest extends PreprocessorCase {
       preprocessor.execute(ADAPTER_XML, new ServiceTestConfig());
       fail();
     } catch (PreprocessorException e) {
-      assertEquals("Failed to find service: channel: [channel-1] workflow: [workflow-1] services: [[service-no-match]] xpath [//channel-list/*[unique-id = 'channel-1']/workflow-list/*[unique-id = 'workflow-1']/service-collection/services//*[unique-id = 'service-no-match']]", e.getMessage());
+      assertEquals("Failed to find service: channel: [channel-1] workflow: [workflow-1] services: [[service-no-match]] xpath [//channel-list/*[unique-id = 'channel-1']/workflow-list/*[unique-id = 'workflow-1']/service-collection/services/*[unique-id = 'service-no-match']]", e.getMessage());
     }
   }
 

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/services/preprocessor/ServiceUniqueIdPreprocessorTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/services/preprocessor/ServiceUniqueIdPreprocessorTest.java
@@ -43,6 +43,10 @@ public class ServiceUniqueIdPreprocessorTest extends PreprocessorCase {
   private static final String SINGLE_SERVICE_XPATH = "//*[unique-id = 'service-1']";
   private static final String MULTI_SERVICE_XPATH = SINGLE_SERVICE_XPATH + "/services/*[unique-id = 'service-2']";
 
+  private static final String ADAPTER_XML_WITH_CONDITION = "<adapter><channel-list><channel><unique-id>channel</unique-id><workflow-list><standard-workflow><unique-id>workflow</unique-id><service-collection class=\"service-list\"><unique-id>serene-fermi</unique-id><services><switch><unique-id>switch</unique-id><case><condition class=\"metadata\"><operator class=\"metadata-ends-with-ignore-case\"><result-key>comparison-result-json</result-key><value>.json</value><ignore-case>true</ignore-case></operator><metadata-key>originalname</metadata-key></condition><service class=\"service-list\"><unique-id>json-case</unique-id><services><logging-service><unique-id>log-json</unique-id><log-level>DEBUG</log-level><text>Processing JSON file</text></logging-service><add-metadata-service><unique-id>set-metadata-action-json</unique-id><metadata-element><key>action</key><value>json</value></metadata-element></add-metadata-service></services></service></case><case><condition class=\"metadata\"><operator class=\"metadata-ends-with-ignore-case\"><result-key>comparison-result-xml</result-key><value>.xml</value><ignore-case>true</ignore-case></operator><metadata-key>originalname</metadata-key></condition><service class=\"service-list\"><unique-id>xml-case</unique-id><services><logging-service><unique-id>log-xml</unique-id><log-level>DEBUG</log-level><text>Processing XML file</text></logging-service><add-metadata-service><unique-id>set-metadata-action-xml</unique-id><metadata-element><key>action</key><value>xml</value></metadata-element></add-metadata-service></services></service></case><case><condition class=\"case-default\"/><service class=\"service-list\"><unique-id>default-case</unique-id><services><logging-service><unique-id>log-file</unique-id><log-level>DEBUG</log-level><text>Processing unknown file</text></logging-service><add-metadata-service><unique-id>set-metadata-action-default</unique-id><metadata-element><key>action</key><value>default</value></metadata-element></add-metadata-service></services></service></case></switch></services></service-collection></standard-workflow></workflow-list></channel></channel-list></adapter>";
+  private static final String SERVICE_IN_CONDITION_1 = "<service class=\"service-list\"><unique-id>json-case</unique-id><services><logging-service><unique-id>log-json</unique-id><log-level>DEBUG</log-level><text>Processing JSON file</text></logging-service><add-metadata-service><unique-id>set-metadata-action-json</unique-id><metadata-element><key>action</key><value>json</value></metadata-element></add-metadata-service></services></service>";
+  private static final String SERVICE_IN_CONDITION_2 = "<service class=\"service-list\"><unique-id>xml-case</unique-id><services><logging-service><unique-id>log-xml</unique-id><log-level>DEBUG</log-level><text>Processing XML file</text></logging-service><add-metadata-service><unique-id>set-metadata-action-xml</unique-id><metadata-element><key>action</key><value>xml</value></metadata-element></add-metadata-service></services></service>";
+
   @Test
   public void testExecute() throws Exception{
     ServiceUniqueIdPreprocessor preprocessor;
@@ -78,6 +82,15 @@ public class ServiceUniqueIdPreprocessorTest extends PreprocessorCase {
     //Shows it works and returns first
     preprocessor = new ServiceUniqueIdPreprocessor(Collections.singletonList("add-metadata"));
     assertEquals(EXPECTED_SINGLE_ADD, preprocessor.execute(ADAPTER_XML, new ServiceTestConfig()));
+  }
+
+  @Test
+  public void testServiceInCondition() throws Exception {
+    ServiceUniqueIdPreprocessor preprocessor = new ServiceUniqueIdPreprocessor("channel", "workflow", Collections.singletonList("json-case"));
+    assertEquals(SERVICE_IN_CONDITION_1, preprocessor.execute(ADAPTER_XML_WITH_CONDITION, new ServiceTestConfig()));
+
+    preprocessor = new ServiceUniqueIdPreprocessor(Collections.singletonList("xml-case"));
+    assertEquals(SERVICE_IN_CONDITION_2, preprocessor.execute(ADAPTER_XML_WITH_CONDITION, new ServiceTestConfig()));
   }
 
   @Test


### PR DESCRIPTION
## Motivation

The service-tester does not support testing individual services inside conditions (if/switch etc).

## Modification

Add an extra `/` to the XPath used to identify services in the `ServiceUniqueIdPreprocessor`. This will mean that the XPath will find the service with the given unique ID at any point below the matched channel & workflow, and not just as a immediate child.

## PR Checklist

- [x] been self-reviewed.
- [x] Added unit tests or modified existing tests to cover new code paths
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Checked the display of the component in the UI

## Result

The user can now identify a service within a conditional as a descendent of a given channel & workflow. An alternative workaround would be not to set a channel or workflow and the generated XPath would already find the required service.

## Testing

Find [attached](https://github.com/adaptris/interlok-service-tester/files/6785183/switch-test.zip) a project with adapter config and service-tester config. There is a test case the targets one of the services within the switch service.