### PR TITLE
INTERLOK-3839 Stop adding to unmodifiable map

### DIFF
--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/TestMessageProvider.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/TestMessageProvider.java
@@ -26,6 +26,10 @@ import com.adaptris.tester.runtime.messages.payload.PayloadProvider;
 import com.adaptris.util.text.mime.MimeConstants;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  *
  * @service-test-config test-message-provider
@@ -67,10 +71,15 @@ public class TestMessageProvider {
   public TestMessage createTestMessage(ServiceTestConfig config) throws MessageException {
     getMetadataProvider().init(config);
     getPayloadProvider().init(config);
-    TestMessage message = new TestMessage(getMetadataProvider().getMessageHeaders(), getPayloadProvider().getPayload());
-    if (getPayloadProvider() instanceof FilePayloadProvider) {
-      message.addMessageHeader(CoreConstants.SERIALIZED_MESSAGE_ENCODING, MimeConstants.ENCODING_BASE64);
+    Map<String, String> headers = getMetadataProvider().getMessageHeaders();
+    if (getPayloadProvider() instanceof FilePayloadProvider)
+    { // The map seems to want to be unmodifiable, but we need to
+      // sneakily indicate that the message is binary data that's been
+      // base-64 encoded.
+      headers = new HashMap<>(headers);
+      headers.put(CoreConstants.SERIALIZED_MESSAGE_ENCODING, MimeConstants.ENCODING_BASE64);
+      headers = Collections.unmodifiableMap(headers);
     }
-    return message;
+    return new TestMessage(headers, getPayloadProvider().getPayload());
   }
 }


### PR DESCRIPTION
## Motivation

The service tester was throwing exceptions when using a file payload provider because it tries to add metadata to the message but the headers are (by that time) in an unmodifiable map.

## Modification

* Put the existing headers into a new map
* Add the new header that identifies the payload as now being base-64 encoded
* Put all the headers back into an unmodifiable map

## PR Checklist

- [x] been self-reviewed.
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI

## Result

The service tester should no longer throw an Unsupported Operation exception.

## Testing

Use [adapter.xml](https://github.com/adaptris/interlok-service-tester/files/7129120/adapter.xml.txt) and 
[service-tester.xml](https://github.com/adaptris/interlok-service-tester/files/7129135/service-tester.xml.txt) (you may need to change some paths).

Before the fix, the service tester should throw an Unsupported Operation exception because the service tester is trying to add items to an unmodifiable map, with the fix it should run without throwing anything.

