### PR TITLE
Variable Substitution needs to be service-tester working dir aware.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ bin
 gradle.properties
 unit-tests.properties
 unit-tests.properties.resolved
+**/src/main/generated

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -4,6 +4,8 @@ extraction:
       java_version: 11
       gradle:
         version: 7.1
+      build_command:
+        - ./gradlew --no-daemon -S lgtmCompile
 
 path_classifiers:
   docs:

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
   id 'com.github.spotbugs' version '5.0.5' apply false
   id 'org.owasp.dependencycheck' version '6.5.3' apply false
   id 'nebula.optional-base' version '7.0.0' apply false
+  id "io.freefair.lombok" version "6.4.0" apply false
 }
 
 ext {
@@ -103,12 +104,14 @@ subprojects { subproject ->
   apply plugin: 'com.github.spotbugs'
   apply plugin: 'org.owasp.dependencycheck'
   apply plugin: 'nebula.optional-base'
+  apply plugin: "io.freefair.lombok"
 
   sourceCompatibility = JavaVersion.VERSION_11
   targetCompatibility = JavaVersion.VERSION_11
   group   = 'com.adaptris'
   version = releaseVersion
   def versionDir = "$buildDir/version"
+  lombok.disableConfig = true
 
   repositories {
     mavenCentral()
@@ -236,10 +239,6 @@ subprojects { subproject ->
     }
   }
 
-  task deleteGeneratedFiles(type: Delete) {
-    delete file(testResourcesDir() + "/unit-tests.properties"), file(testResourcesDir() + "/unit-tests.properties.resolved")
-  }
-
   spotbugsMain {
     effort = "max"
     reportLevel = "high"
@@ -280,6 +279,14 @@ subprojects { subproject ->
       }
   }
 
+  task lgtmCompile(type: JavaCompile, dependsOn: delombok) {
+    group 'Build'
+    description 'Compile for lgtm'
+
+    source = sourceSets.main.extensions.delombokTask
+    destinationDirectory= sourceSets.main.java.classesDirectory
+    classpath = project.sourceSets.main.compileClasspath
+  }
+
   check.dependsOn jacocoTestReport
-  clean.dependsOn deleteGeneratedFiles
 }

--- a/build.gradle
+++ b/build.gradle
@@ -157,9 +157,9 @@ subprojects { subproject ->
 
     api ("com.adaptris:interlok-core:$interlokCoreVersion") {changing= true}
     api ("com.adaptris:interlok-common:$interlokCoreVersion") {changing= true}
-    api ("org.slf4j:slf4j-api:$slf4jVersion")
     api files("${System.getProperty('java.home')}/../lib/tools.jar")
 
+    implementation ("org.slf4j:slf4j-api:$slf4jVersion")
     annotationProcessor ("com.adaptris:interlok-core-apt:$interlokCoreVersion") {changing= true}
     testAnnotationProcessor ("com.adaptris:interlok-core-apt:$interlokCoreVersion") {changing= true}
     testImplementation ('junit:junit:4.13.2')

--- a/interlok-service-tester-gradle/build.gradle
+++ b/interlok-service-tester-gradle/build.gradle
@@ -1,6 +1,7 @@
 ext {
   componentName='Interlok Service Tester/gradle'
   componentDesc="Experimental Gradle plugin for service-tester"
+  delombokTargetDir = new File("${project.projectDir}/src/main/generated")
 }
 
 group   = 'com.adaptris.labs'
@@ -23,12 +24,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
-    from sourceSets.main.allSource
-}
-
-task examplesJar(type: Jar, dependsOn: test) {
-  classifier = 'examples'
-  from new File(buildDir, '/examples')
+    from sourceSets.main.extensions.delombokTask
 }
 
 jar {
@@ -44,7 +40,6 @@ jar {
 artifacts {
   archives javadocJar
   archives sourcesJar
-  archives examplesJar
 }
 
 publishing {
@@ -54,7 +49,6 @@ publishing {
 
       artifact javadocJar { classifier "javadoc" }
       artifact sourcesJar { classifier "sources" }
-      artifact examplesJar { classifier "examples" }
 
       pom.withXml {
         asNode().appendNode("name", componentName)
@@ -108,7 +102,7 @@ task umlJavadoc(type: Javadoc) {
   onlyIf {
     hasGraphViz()
   }
-  source = sourceSets.main.allJava
+  source = sourceSets.main.extensions.delombokTask
   classpath = project.sourceSets.main.compileClasspath
   configure(options) {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
@@ -143,5 +137,15 @@ task umlJavadoc(type: Javadoc) {
   }
 }
 
+task deleteGeneratedFiles(type: Delete) {
+  delete file(testResourcesDir() + "/unit-tests.properties"), file(testResourcesDir() + "/unit-tests.properties.resolved")
+  delete delombokTargetDir, "derby.log"
+}
+
+delombok {
+  target = delombokTargetDir
+}
+
+clean.dependsOn deleteGeneratedFiles
 javadoc.dependsOn offlinePackageList,umlJavadoc
 processTestResources.dependsOn copyUnitTestProperties

--- a/interlok-service-tester-json/build.gradle
+++ b/interlok-service-tester-json/build.gradle
@@ -1,7 +1,8 @@
 ext {
   componentName='Interlok Service Tester/JSON'
   componentDesc="JSON Assertions for service-tester"
- jacksonVersion='2.13.1'
+  jacksonVersion='2.13.1'
+  delombokTargetDir = new File("${project.projectDir}/src/main/generated")
 }
 
 dependencies {
@@ -25,12 +26,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
-    from sourceSets.main.allSource
-}
-
-task examplesJar(type: Jar, dependsOn: test) {
-  classifier = 'examples'
-  from new File(buildDir, '/examples')
+    from sourceSets.main.extensions.delombokTask
 }
 
 jar {
@@ -46,7 +42,6 @@ jar {
 artifacts {
   archives javadocJar
   archives sourcesJar
-  archives examplesJar
 }
 
 publishing {
@@ -56,7 +51,6 @@ publishing {
 
       artifact javadocJar { classifier "javadoc" }
       artifact sourcesJar { classifier "sources" }
-      artifact examplesJar { classifier "examples" }
 
       pom.withXml {
         asNode().appendNode("name", componentName)
@@ -110,7 +104,7 @@ task umlJavadoc(type: Javadoc) {
   onlyIf {
     hasGraphViz()
   }
-  source = sourceSets.main.allJava
+  source = sourceSets.main.extensions.delombokTask
   classpath = project.sourceSets.main.compileClasspath
   configure(options) {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
@@ -144,6 +138,15 @@ task umlJavadoc(type: Javadoc) {
     options.addStringOption "umlIncludeProtectedInnerClasses","false"
   }
 }
+task deleteGeneratedFiles(type: Delete) {
+  delete file(testResourcesDir() + "/unit-tests.properties"), file(testResourcesDir() + "/unit-tests.properties.resolved")
+  delete delombokTargetDir, "derby.log"
+}
 
+delombok {
+  target = delombokTargetDir
+}
+
+clean.dependsOn deleteGeneratedFiles
 javadoc.dependsOn offlinePackageList,umlJavadoc
 processTestResources.dependsOn copyUnitTestProperties

--- a/interlok-service-tester-wiremock/build.gradle
+++ b/interlok-service-tester-wiremock/build.gradle
@@ -1,6 +1,7 @@
 ext {
   componentName='Interlok Service Tester/Wiremock'
   componentDesc="Wiremock boostrapper for service-tester"
+  delombokTargetDir = new File("${project.projectDir}/src/main/generated")
   jacksonVersion='2.13.1'
 }
 
@@ -27,13 +28,9 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
-    from sourceSets.main.allSource
+    from sourceSets.main.extensions.delombokTask
 }
 
-task examplesJar(type: Jar, dependsOn: test) {
-  classifier = 'examples'
-  from new File(buildDir, '/examples')
-}
 
 jar {
   manifest {
@@ -48,7 +45,6 @@ jar {
 artifacts {
   archives javadocJar
   archives sourcesJar
-  archives examplesJar
 }
 
 publishing {
@@ -58,7 +54,6 @@ publishing {
 
       artifact javadocJar { classifier "javadoc" }
       artifact sourcesJar { classifier "sources" }
-      artifact examplesJar { classifier "examples" }
 
       pom.withXml {
         asNode().appendNode("name", componentName)
@@ -112,7 +107,7 @@ task umlJavadoc(type: Javadoc) {
   onlyIf {
     hasGraphViz()
   }
-  source = sourceSets.main.allJava
+  source = sourceSets.main.extensions.delombokTask
   classpath = project.sourceSets.main.compileClasspath
   configure(options) {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
@@ -146,6 +141,15 @@ task umlJavadoc(type: Javadoc) {
     options.addStringOption "umlIncludeProtectedInnerClasses","false"
   }
 }
+task deleteGeneratedFiles(type: Delete) {
+  delete file(testResourcesDir() + "/unit-tests.properties"), file(testResourcesDir() + "/unit-tests.properties.resolved")
+  delete delombokTargetDir, "derby.log"
+}
 
+delombok {
+  target = delombokTargetDir
+}
+
+clean.dependsOn deleteGeneratedFiles
 javadoc.dependsOn offlinePackageList,umlJavadoc
 processTestResources.dependsOn copyUnitTestProperties

--- a/interlok-service-tester-xml/build.gradle
+++ b/interlok-service-tester-xml/build.gradle
@@ -1,6 +1,7 @@
 ext {
   componentName='Interlok Service Tester/XML'
   componentDesc="XML Assertions for service-tester using xmlunit"
+  delombokTargetDir = new File("${project.projectDir}/src/main/generated")
 }
 
 dependencies {
@@ -18,13 +19,9 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
-    from sourceSets.main.allSource
+    from sourceSets.main.extensions.delombokTask
 }
 
-task examplesJar(type: Jar, dependsOn: test) {
-  classifier = 'examples'
-  from new File(buildDir, '/examples')
-}
 
 jar {
   manifest {
@@ -39,7 +36,6 @@ jar {
 artifacts {
   archives javadocJar
   archives sourcesJar
-  archives examplesJar
 }
 
 publishing {
@@ -49,7 +45,6 @@ publishing {
 
       artifact javadocJar { classifier "javadoc" }
       artifact sourcesJar { classifier "sources" }
-      artifact examplesJar { classifier "examples" }
 
       pom.withXml {
         asNode().appendNode("name", componentName)
@@ -102,7 +97,7 @@ task umlJavadoc(type: Javadoc) {
   onlyIf {
     hasGraphViz()
   }
-  source = sourceSets.main.allJava
+  source = sourceSets.main.extensions.delombokTask
   classpath = project.sourceSets.main.compileClasspath
   configure(options) {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
@@ -135,6 +130,17 @@ task umlJavadoc(type: Javadoc) {
     options.addStringOption "umlIncludeProtectedInnerClasses","false"
   }
 }
+
+task deleteGeneratedFiles(type: Delete) {
+  delete file(testResourcesDir() + "/unit-tests.properties"), file(testResourcesDir() + "/unit-tests.properties.resolved")
+  delete delombokTargetDir, "derby.log"
+}
+
+delombok {
+  target = delombokTargetDir
+}
+
+clean.dependsOn deleteGeneratedFiles
 
 javadoc.dependsOn offlinePackageList,umlJavadoc
 processTestResources.dependsOn copyUnitTestProperties

--- a/interlok-service-tester/build.gradle
+++ b/interlok-service-tester/build.gradle
@@ -1,6 +1,7 @@
 ext {
   componentName='Interlok Service Tester/Core'
   componentDesc="Unit testing framework for Interlok"
+  delombokTargetDir = new File("${project.projectDir}/src/main/generated")
 }
 
 dependencies {
@@ -16,12 +17,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 
 task sourcesJar(type: Jar, dependsOn: classes) {
     classifier = 'sources'
-    from sourceSets.main.allSource
-}
-
-task examplesJar(type: Jar, dependsOn: test) {
-  classifier = 'examples'
-  from new File(buildDir, '/examples')
+    from sourceSets.main.extensions.delombokTask
 }
 
 jar {
@@ -37,7 +33,6 @@ jar {
 artifacts {
   archives javadocJar
   archives sourcesJar
-  archives examplesJar
 }
 
 publishing {
@@ -47,7 +42,6 @@ publishing {
 
       artifact javadocJar { classifier "javadoc" }
       artifact sourcesJar { classifier "sources" }
-      artifact examplesJar { classifier "examples" }
 
       pom.withXml {
         asNode().appendNode("name", componentName)
@@ -101,7 +95,7 @@ task umlJavadoc(type: Javadoc) {
   onlyIf {
     hasGraphViz()
   }
-  source = sourceSets.main.allJava
+  source = sourceSets.main.extensions.delombokTask
   classpath = project.sourceSets.main.compileClasspath
   configure(options) {
     options.linksOffline(interlokJavadocs, offlineJavadocPackageDir.getCanonicalPath() + "/interlok-core-$interlokCoreVersion-javadoc.jar")
@@ -136,5 +130,16 @@ task umlJavadoc(type: Javadoc) {
   }
 }
 
+
+task deleteGeneratedFiles(type: Delete) {
+  delete file(testResourcesDir() + "/unit-tests.properties"), file(testResourcesDir() + "/unit-tests.properties.resolved")
+  delete delombokTargetDir, "derby.log"
+}
+
+delombok {
+  target = delombokTargetDir
+}
+
+clean.dependsOn deleteGeneratedFiles
 javadoc.dependsOn offlinePackageList,umlJavadoc
 processTestResources.dependsOn copyUnitTestProperties

--- a/interlok-service-tester/build.gradle
+++ b/interlok-service-tester/build.gradle
@@ -7,6 +7,7 @@ ext {
 dependencies {
   api ("com.adaptris:interlok-varsub:$interlokCoreVersion") { changing= true}
   api ("com.adaptris:interlok-xinclude:$interlokCoreVersion"){ changing= true}
+  implementation ("commons-io:commons-io:2.11.0")
   testImplementation ("com.github.stefanbirkner:system-rules:1.19.0")
 }
 

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/preprocessor/Preprocessor.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/preprocessor/Preprocessor.java
@@ -28,4 +28,15 @@ public interface Preprocessor {
    * @throws PreprocessorException wraps any thrown Exception
    */
   String execute(String input, ServiceTestConfig config) throws PreprocessorException;
+
+  static PreprocessorException wrapException(Exception e) {
+    return wrapException(e.getMessage(), e);
+  }
+
+  static PreprocessorException wrapException(String msg, Exception e) {
+    if (e instanceof PreprocessorException) {
+      return (PreprocessorException) e;
+    }
+    return new PreprocessorException(msg, e);
+  }
 }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/preprocessor/VarSubPreprocessor.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/preprocessor/VarSubPreprocessor.java
@@ -19,7 +19,6 @@ package com.adaptris.tester.runtime.services.preprocessor;
 import static com.adaptris.tester.runtime.ServiceTestConfig.SERVICE_TESTER_WORKING_DIRECTORY;
 import static com.adaptris.tester.runtime.services.preprocessor.Preprocessor.wrapException;
 
-import com.adaptris.core.CoreException;
 import com.adaptris.core.varsub.Constants;
 import com.adaptris.core.varsub.VariableSubstitutionPreProcessor;
 import com.adaptris.tester.runtime.ServiceTestConfig;
@@ -64,8 +63,8 @@ public class VarSubPreprocessor implements Preprocessor {
     try {
       VariableSubstitutionPreProcessor processor = new VariableSubstitutionPreProcessor(createPropertyFileSet(config));
       return processor.process(input);
-    } catch (CoreException e) {
-      throw Preprocessor.wrapException("Failed to substitute variables", e);
+    } catch (Exception e) {
+      throw wrapException("Failed to substitute variables", e);
     }
   }
 
@@ -76,27 +75,21 @@ public class VarSubPreprocessor implements Preprocessor {
   // Create a
   // service.tester.working.directory=XXXX property so we can refer to it
   // if it's not already been defined.
-  private File createServiceTesterWorkingDirProperty(ServiceTestConfig config) throws PreprocessorException {
-    File result;
-
-    try {
-      result =createTrackedFile(this);
-      Properties properties = new Properties();
-      properties.put(SERVICE_TESTER_WORKING_DIRECTORY, config.workingDirectory.getAbsolutePath());
-      try (FileOutputStream out = new FileOutputStream(result)) {
-        properties.store(out, "");
-      }
-    } catch (Exception e) {
-      throw Preprocessor.wrapException(e);
+  private File createServiceTesterWorkingDirProperty(ServiceTestConfig config) throws Exception {
+    File result =createTrackedFile(this);
+    Properties properties = new Properties();
+    properties.put(SERVICE_TESTER_WORKING_DIRECTORY, config.workingDirectory.getAbsolutePath());
+    try (FileOutputStream out = new FileOutputStream(result)) {
+      properties.store(out, "");
     }
     return result;
   }
 
   private KeyValuePairSet createPropertyFileSet(ServiceTestConfig config) throws PreprocessorException {
-    if (propertyFile.size() == 0) {
-      throw new PreprocessorException("At least one properties file must be set");
-    }
     try {
+      if (propertyFile.size() == 0) {
+        throw new PreprocessorException("At least one properties file must be set");
+      }
       KeyValuePairSet kvp = new KeyValuePairSet();
       kvp.addKeyValuePair(new KeyValuePair(Constants.VARSUB_PROPERTIES_URL_KEY + ".00",
           "file:///" + createServiceTesterWorkingDirProperty(config).getAbsolutePath()));

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/preprocessor/VarSubPreprocessor.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/services/preprocessor/VarSubPreprocessor.java
@@ -114,7 +114,7 @@ public class VarSubPreprocessor implements Preprocessor {
   }
 
   private static File createTrackedFile(Object tracker) throws IOException {
-    File f = File.createTempFile("VarSubPreprocessor", "", null);
+    File f = File.createTempFile("interlok-stwd", "", null);
     return trackFile(f, tracker);
   }
 

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/services/preprocessor/PreprocessorCase.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/services/preprocessor/PreprocessorCase.java
@@ -16,7 +16,10 @@
 
 package com.adaptris.tester.runtime.services.preprocessor;
 
+import static org.junit.Assert.assertEquals;
+
 import com.adaptris.tester.STExampleConfigCase;
+import org.junit.Test;
 
 public abstract class PreprocessorCase extends STExampleConfigCase {
 
@@ -30,6 +33,16 @@ public abstract class PreprocessorCase extends STExampleConfigCase {
     if (PROPERTIES.getProperty(BASE_DIR_KEY) != null) {
       setBaseDir(PROPERTIES.getProperty(BASE_DIR_KEY));
     }
+  }
+
+  @Test
+  public void testWrapException() {
+    Exception e1 = new Exception();
+    PreprocessorException wrapped = Preprocessor.wrapException(e1);
+    assertEquals(e1, wrapped.getCause());
+    PreprocessorException e2 = new PreprocessorException("XXX");
+    wrapped = Preprocessor.wrapException(e2);
+    assertEquals(e2, wrapped);
   }
 
   @Override


### PR DESCRIPTION
## Motivation

If you have configuration like this, such that a file based URL is a variable.

```
          <json-transform-service>
            <unique-id>remove-spurious-stuffs</unique-id>
            <source-json class="string-payload-data-input-parameter"/>
            <mapping-spec class="file-data-input-parameter">
              <url>${jolt.eff}</url>
            </mapping-spec>
            <target-json class="string-payload-data-output-parameter"/>
            <metadata-filter class="remove-all-metadata-filter"/>
          </json-transform-service>
```

It's hard to configure and test using service-tester such that it is "easily" switchable between the UI and `./gradlew check`

Basically you need to introduce a `properties-variable-substitution-processor` since this is _working.directory_ aware.  If you don't use a props-varsub-processor then you end up in a situation where it will either run via the UI or it will run via gradlew but not both!

```
      <service-to-test>
        <source class="default-config-file-source">
          <file>file:///${service.tester.working.directory}/src/main/interlok/config/adapter.xml</file>
        </source>
        <preprocessors>
          <service-unique-id-preprocessor>
            <service>eff-json</service>
          </service-unique-id-preprocessor>
          <properties-variable-substitution-preprocessor>
            <properties>
              <key-value-pair>
                <key>jolt.eff</key>
                <value>file:///${service.tester.working.directory}/src/main/interlok/config/transforms/eff-jolt.json</value>
              </key-value-pair>
            </properties>
          <properties-variable-substitution-processor/>
          <variable-substitution-preprocessor>
            <property-file>file:///${service.tester.working.directory}/src/main/interlok/config/variables.properties</property-file>
            <property-file>file:///${service.tester.working.directory}/src/main/interlok/config/variables-local-dev.properties</property-file>
          </variable-substitution-preprocessor>
        </preprocessors>
      </service-to-test>
```

This is fine for the most trivial of use cases (because varsub-properties-processor runs first, you effectively have nothing left to replace by the time you get to varsub-processor), but as soon as you have many file references you are then in the position that you are duplicating static configuration for every test that relies on a file-url (e.g. xml-transform, flatfile-transform, json-transform etc) in your configuration.

## Modification

- Enabled for lombok (hopefully cherry-pickable)
- Modified `variable-substitution-processor` such that it generates a temporary file that contains the definition for `service.tester.working.directory` and makes sure that it is _first_ in the list of property files that is generated for use.
    - It's a tracked file, so should get deleted after JVM exit.
    - If it's not defined explicitly in your property files, you can still refer to "${service.tester.working.directory}" without it failing during the substitution phase.
    - If you have explicitly defined it, then that will take precedence anyway.

That means that you can have something like this instead : 

```
      <service-to-test>
        <source class="default-config-file-source">
          <file>file:///${service.tester.working.directory}/src/main/interlok/config/adapter.xml</file>
        </source>
        <preprocessors>
          <service-unique-id-preprocessor>
            <service>eff-json</service>
          </service-unique-id-preprocessor>
          <variable-substitution-preprocessor>
            <property-file>file:///${service.tester.working.directory}/src/main/interlok/config/variables.properties</property-file>
            <property-file>file:///${service.tester.working.directory}/src/main/interlok/config/variables-local-dev.properties</property-file>
            <property-file>file:///${service.tester.working.directory}/src/test/interlok/variables-service-tester.properties</property-file>
          </variable-substitution-preprocessor>
        </preprocessors>
      </service-to-test>
```

And you can now maintain src/test/interlok/variables-service-tester.properties independently as required.

## PR Checklist

- [x] been self-reviewed.

## Result

- There is no UI change for the user.
- You can now use VarSubProcessor in the UI and from build.gradle in an equivalent fashion.

## Testing

- Choose a service that requires a file based URL (one of the transform services will do).
- Make sure it's configured with a variable
- Create tests to test the transform
- See configuration above.

## Notes

Is there a case that service-tester should have a "global pre-processors" as part of the `service-test` element to cut down even more configuration duplication?
