### PR TITLE
INTERLOK-4531: Support multi payload for service tester

### DIFF
--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/MessageTranslator.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/MessageTranslator.java
@@ -16,22 +16,54 @@
 
 package com.adaptris.tester.runtime.messages;
 
+import com.adaptris.core.MultiPayloadAdaptrisMessage;
+import com.adaptris.core.MultiPayloadAdaptrisMessageImp;
+import com.adaptris.core.MultiPayloadMessageFactory;
 import com.adaptris.core.SerializableAdaptrisMessage;
+import com.adaptris.interlok.types.InterlokMessage;
+import com.adaptris.interlok.types.SerializableInterlokMessageAdapter;
 import com.adaptris.interlok.types.SerializableMessage;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class MessageTranslator {
+  private final MultiPayloadMessageFactory multiPayloadMessageFactory = new MultiPayloadMessageFactory();
 
   public TestMessage translate(SerializableMessage message){
-    TestMessage tm = new TestMessage(message.getMessageHeaders(), message.getContent());
+    TestMessage tm = null;
+    if (message instanceof SerializableInterlokMessageAdapter adapter) {
+      InterlokMessage actual = adapter.getMessage();
+      if (actual instanceof MultiPayloadAdaptrisMessage multi) {
+        Map<String, MultiPayloadAdaptrisMessageImp.Payload> payloads = new HashMap<>();
+        multi.getPayloadIDs().forEach(pid -> {
+          byte[] payload = multi.getPayload(pid);
+          payloads.put(pid, new MultiPayloadAdaptrisMessageImp.Payload(multi.getContentEncoding(pid), payload));
+        });
+        tm = new TestMessage(message.getMessageHeaders(), payloads);
+      }
+    }
+    if (tm == null) {
+      tm = new TestMessage(message.getMessageHeaders(), message.getContent());
+    }
     tm.setNextServiceId(message.getNextServiceId());
     return tm;
   }
 
-  public SerializableAdaptrisMessage translate(TestMessage input) {
-    SerializableAdaptrisMessage message = new SerializableAdaptrisMessage();
-    message.setContent(input.getPayload());
+  public SerializableMessage translate(TestMessage input) {
+    SerializableMessage message;
+    if (input.getMultiPayload()) {
+      MultiPayloadAdaptrisMessage multiPayloadMessage = (MultiPayloadAdaptrisMessage) multiPayloadMessageFactory.newMessage();
+      input.getPayloads().forEach( (payloadId, payload) -> {
+        multiPayloadMessage.addPayload(payloadId, payload.getData());
+      });
+      message = new SerializableInterlokMessageAdapter(multiPayloadMessage);
+    } else {
+      message = new SerializableAdaptrisMessage();
+      message.setContent(input.getPayload());
+    }
     message.setMessageHeaders(input.getMessageHeaders());
-    message.setNextServiceId(null);
+    message.setNextServiceId("");
     return message;
   }
 }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/TestMessage.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/TestMessage.java
@@ -16,8 +16,11 @@
 
 package com.adaptris.tester.runtime.messages;
 
+import com.adaptris.core.MultiPayloadAdaptrisMessage;
+import com.adaptris.core.MultiPayloadAdaptrisMessageImp;
 import com.thoughtworks.xstream.annotations.XStreamOmitField;
 
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,12 +29,15 @@ public class TestMessage{
   @XStreamOmitField
   private Map<String, String> messageHeaders;
   @XStreamOmitField
-  private String payload;
+  private Map<String, MultiPayloadAdaptrisMessageImp.Payload> payloads;
   @XStreamOmitField
   private String nextServiceId;
 
+  private Boolean isMultiPayload = false;
+
   public TestMessage(){
     setMessageHeaders(new HashMap<String, String>());
+    payloads = new HashMap<>();
     setPayload("");
     setNextServiceId("");
   }
@@ -39,6 +45,13 @@ public class TestMessage{
   public TestMessage(Map<String, String> messageHeaders, String payload){
     setMessageHeaders(messageHeaders);
     setPayload(payload);
+    setNextServiceId("");
+  }
+
+  public TestMessage(Map<String, String> messageHeaders, Map<String, MultiPayloadAdaptrisMessageImp.Payload> payloads){
+    setMessageHeaders(messageHeaders);
+    this.payloads = payloads;
+    setMultiPayload(true);
     setNextServiceId("");
   }
 
@@ -55,11 +68,16 @@ public class TestMessage{
   }
 
   public String getPayload() {
-    return payload;
+    return payloads.get(MultiPayloadAdaptrisMessage.DEFAULT_PAYLOAD_ID).getPayloadAsString();
   }
 
   public void setPayload(String payload) {
-    this.payload = payload;
+    if (this.payloads == null) this.payloads = new HashMap<>();
+    this.payloads.put(MultiPayloadAdaptrisMessage.DEFAULT_PAYLOAD_ID, new MultiPayloadAdaptrisMessageImp.Payload(Charset.defaultCharset().name(), payload.getBytes()));
+  }
+
+  public Map<String, MultiPayloadAdaptrisMessageImp.Payload> getPayloads() {
+    return payloads;
   }
 
   public String getNextServiceId() {
@@ -68,6 +86,14 @@ public class TestMessage{
 
   public void setNextServiceId(String nextServiceId) {
     this.nextServiceId = nextServiceId;
+  }
+
+  public Boolean getMultiPayload() {
+    return Boolean.TRUE.equals(isMultiPayload);
+  }
+
+  public void setMultiPayload(Boolean multiPayload) {
+    isMultiPayload = multiPayload;
   }
 
   @Override

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/TestMessageProvider.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/TestMessageProvider.java
@@ -22,6 +22,7 @@ import com.adaptris.tester.runtime.messages.metadata.EmptyMetadataProvider;
 import com.adaptris.tester.runtime.messages.metadata.MetadataProvider;
 import com.adaptris.tester.runtime.messages.payload.EmptyPayloadProvider;
 import com.adaptris.tester.runtime.messages.payload.FilePayloadProvider;
+import com.adaptris.tester.runtime.messages.payload.MultiPayloadProvider;
 import com.adaptris.tester.runtime.messages.payload.PayloadProvider;
 import com.adaptris.util.text.mime.MimeConstants;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
@@ -79,6 +80,10 @@ public class TestMessageProvider {
       headers = new HashMap<>(headers);
       headers.put(CoreConstants.SERIALIZED_MESSAGE_ENCODING, MimeConstants.ENCODING_BASE64);
       headers = Collections.unmodifiableMap(headers);
+    }
+
+    if (getPayloadProvider() instanceof MultiPayloadProvider mpp) {
+      return new TestMessage(headers, mpp.getMultiPayload());
     }
     return new TestMessage(headers, getPayloadProvider().getPayload());
   }

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/payload/MultiPayload.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/payload/MultiPayload.java
@@ -1,0 +1,33 @@
+/*
+    Copyright 2018 Adaptris Ltd.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.tester.runtime.messages.payload;
+
+import com.adaptris.core.MultiPayloadAdaptrisMessageImp;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import com.thoughtworks.xstream.annotations.XStreamConverter;
+import com.thoughtworks.xstream.converters.collections.MapConverter;
+
+import java.util.HashMap;
+/**
+ *
+ * @service-test-config multi-payload
+ */
+@XStreamAlias("multi-payload")
+@XStreamConverter(MapConverter.class)
+public class MultiPayload extends HashMap<String, MultiPayloadAdaptrisMessageImp.Payload> {
+
+}

--- a/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/payload/MultiPayloadProvider.java
+++ b/interlok-service-tester/src/main/java/com/adaptris/tester/runtime/messages/payload/MultiPayloadProvider.java
@@ -1,0 +1,54 @@
+/*
+    Copyright 2018 Adaptris Ltd.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.adaptris.tester.runtime.messages.payload;
+
+import com.adaptris.core.*;
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import java.nio.charset.Charset;
+
+/**
+ *
+ * @service-test-config multi-payload-provider
+ */
+@XStreamAlias("multi-payload-provider")
+public class MultiPayloadProvider extends PayloadProvider {
+
+  private MultiPayload multiPayload = new MultiPayload();
+
+  public MultiPayloadProvider() {}
+
+  public MultiPayloadProvider(MultiPayload payloads) {
+    this.multiPayload = payloads;
+  }
+
+  public MultiPayload getMultiPayload() {
+    return multiPayload;
+  }
+
+  public void setMultiPayload(MultiPayload payloads) {
+    this.multiPayload = payloads;
+  }
+
+  @Override
+  public String getPayload() {
+    return this.multiPayload != null ? this.multiPayload.get(MultiPayloadAdaptrisMessage.DEFAULT_PAYLOAD_ID).getPayloadAsString() : null;
+  }
+
+  public void setPayload(String payload) {
+    this.multiPayload.put(MultiPayloadAdaptrisMessage.DEFAULT_PAYLOAD_ID, new MultiPayloadAdaptrisMessageImp.Payload(Charset.defaultCharset().name(), payload.getBytes()));
+  }
+}

--- a/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/MessageTranslatorTest.java
+++ b/interlok-service-tester/src/test/java/com/adaptris/tester/runtime/messages/MessageTranslatorTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.adaptris.interlok.types.SerializableMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -59,7 +60,7 @@ public class MessageTranslatorTest {
   @Test
   public void testTranslateTestMessage() throws Exception {
     MessageTranslator t = new MessageTranslator();
-    SerializableAdaptrisMessage sm = t.translate(new TestMessage(metadata, PAYLOAD));
+    SerializableMessage sm = t.translate(new TestMessage(metadata, PAYLOAD));
     assertEquals(PAYLOAD, sm.getContent());
     assertEquals(1, sm.getMessageHeaders().size());
     assertTrue(sm.getMessageHeaders().containsKey(METADATA_KEY));


### PR DESCRIPTION
## Motivation

https://adaptris.atlassian.net/browse/INTERLOK-4531

## Modification

- Added a MultiPayloadProvider
- Implemented a way to translate between TestMessage and multi payload message

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result



## Testing


